### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
-export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? '/een-observation-app/' : '/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/een-observation-app/' : '/',
   plugins: [vue()],
   resolve: {
     alias: {
@@ -16,4 +16,4 @@ export default defineConfig({
     strictPort: true,
     open: true
   }
-})
+}))


### PR DESCRIPTION
## Summary
- Fix vite base path detection using `command === 'build'` instead of `NODE_ENV`
- Ensures correct asset paths (`/een-observation-app/`) on GitHub Pages

## Test plan
- [ ] Merge and verify deployment succeeds
- [ ] Confirm site loads at https://klaushofrichter.github.io/een-observation-app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)