### PR TITLE
Use dynamic redirect URI for OAuth

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ app.use(createPinia())
 // Use current origin for redirect URI to support both local dev and GitHub Pages
 const redirectUri = import.meta.env.DEV
   ? 'http://127.0.0.1:3333'
-  : window.location.origin + import.meta.env.BASE_URL
+  : (window.location.origin + import.meta.env.BASE_URL).replace(/\/$/, '')
 
 initEenToolkit({
   proxyUrl: import.meta.env.VITE_PROXY_URL,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,11 +11,15 @@ const app = createApp(App)
 app.use(createPinia())
 
 // Initialize EEN API Toolkit
-// Port 3333 is required by the EEN IDP
+// Use current origin for redirect URI to support both local dev and GitHub Pages
+const redirectUri = import.meta.env.DEV
+  ? 'http://127.0.0.1:3333'
+  : window.location.origin + import.meta.env.BASE_URL
+
 initEenToolkit({
   proxyUrl: import.meta.env.VITE_PROXY_URL,
   clientId: import.meta.env.VITE_EEN_CLIENT_ID,
-  redirectUri: 'http://127.0.0.1:3333',
+  redirectUri,
   storageStrategy: 'localStorage',
   debug: true
 })


### PR DESCRIPTION
## Summary
- Use dynamic redirect URI based on environment
- Local dev: `http://127.0.0.1:3333`
- Production: `https://klaushofrichter.github.io/een-observation-app/`

## Important
You'll need to register the GitHub Pages URL as an allowed redirect URI with the EEN OAuth provider.

## Test plan
- [ ] Merge and verify deployment
- [ ] Test OAuth login flow on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)