### PR TITLE
Add URL camera parameter handling and fix auth store initialization

### DIFF
--- a/.claude/agents/een-auth-agent.md
+++ b/.claude/agents/een-auth-agent.md
@@ -122,6 +122,32 @@ authStore.isAuthenticated // Computed: true if valid token exists
 authStore.isExpired      // Computed: true if token expired
 ```
 
+### authStore.initialize() - Session Restoration (CRITICAL)
+**Must be called in App.vue onMounted to restore sessions from storage.**
+
+Without this call, users must re-login after every page refresh, even with localStorage strategy:
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Restore session from storage on app mount
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+```
+
+What `initialize()` does:
+1. Loads token, expiration, session ID, base URL from storage
+2. If valid token exists: Sets up auto-refresh timer
+3. If expired token: Clears auth state (user must re-login)
+4. If no token: No action (user must login)
+
 ## Auth Guard Pattern
 
 **CRITICAL**: The OAuth callback check MUST come BEFORE the auth check in the global guard.
@@ -297,3 +323,5 @@ async function clearAuthState(page: Page): Promise<void> {
 | invalid_grant | Code expired or reused | Restart OAuth flow |
 | invalid_state | State mismatch | Clear storage, restart flow |
 | REFRESH_FAILED | Refresh token invalid | Redirect to login |
+| Session lost on refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
+| Must login after refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |

--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -269,12 +269,20 @@ async function fetchNotifications() {
 
 ## SSE (Server-Sent Events) for Real-Time Updates
 
+### SSE Subscription Behavior
+
+**Important: TTL is read-only and server-determined**
+- SSE subscriptions have a **15-minute TTL** (900 seconds) set by the server
+- The `timeToLiveSeconds` value **cannot be customized** when creating a subscription
+- The `subscriptionConfig` (including `lifeCycle` and `timeToLiveSeconds`) is returned in the API response but is not a configurable input
+- SSE URLs are **single-use**: once disconnected, you must create a new subscription
+
 ### SSE Lifecycle
 
-1. **Create Subscription** - Get a subscription with SSE URL
+1. **Create Subscription** - Get a subscription with SSE URL (server sets 15-min TTL)
 2. **Connect to Stream** - Open EventSource connection
 3. **Handle Events** - Process events as they arrive
-4. **Cleanup** - Delete subscription when done
+4. **Cleanup** - Delete subscription when done (or it auto-expires after 15 min of inactivity)
 
 ### createEventSubscription()
 ```typescript

--- a/.claude/agents/een-setup-agent.md
+++ b/.claude/agents/een-setup-agent.md
@@ -74,6 +74,35 @@ app.use(router)
 app.mount('#app')
 ```
 
+### App.vue Session Restoration (CRITICAL)
+**Users will need to re-login after every page refresh unless you call `authStore.initialize()` in App.vue.**
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useAuthStore } from 'een-api-toolkit'
+
+const authStore = useAuthStore()
+const isAuthenticated = computed(() => authStore.isAuthenticated)
+
+// CRITICAL: Initialize auth store from storage on app mount
+// This restores the session if a valid token exists in localStorage/sessionStorage
+onMounted(() => {
+  authStore.initialize()
+})
+</script>
+```
+
+Without `initialize()`:
+- Token is saved to localStorage after login ✓
+- On page refresh, Pinia store starts with empty state
+- `isAuthenticated` returns false → user must login again
+
+With `initialize()`:
+- Token is loaded from localStorage on app mount
+- `isAuthenticated` returns true → session is restored
+- User can continue without re-logging in
+
 ### vite.config.ts for EEN OAuth
 ```typescript
 import { defineConfig } from 'vite'
@@ -115,6 +144,7 @@ export default router
 - Pinia must be installed before initEenToolkit()
 - Never add trailing slashes to redirect URIs
 - Ensure VITE_PROXY_URL is set in .env file
+- **Always call `authStore.initialize()` in App.vue onMounted** for session persistence
 
 ## Common Errors and Solutions
 
@@ -124,3 +154,5 @@ export default router
 | "redirect_uri mismatch" | Wrong host/port | Use 127.0.0.1:3333 in vite.config.ts |
 | "Invalid redirect_uri" | Trailing slash | Remove trailing slash from redirect URI |
 | "CORS error" | Proxy not running | Start the OAuth proxy server |
+| Session lost on refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |
+| Must login after refresh | Missing initialize() call | Add `authStore.initialize()` in App.vue onMounted |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/een-api-toolkit": {
-      "version": "0.3.38",
-      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.38.tgz",
-      "integrity": "sha512-aod8ykBOrNoXJ+mFOl7sdF4wb4szoghkso8rUwkbNt9BCAwknu/WDYLb8Q4L4jCvlYp7qf40nSXzi0qvGr38eg==",
+      "version": "0.3.43",
+      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.43.tgz",
+      "integrity": "sha512-Mnf2fZI7GImsK77lI+uoZ9S/ZXF48xpCgBcteQIQrQgpcobMMFUR0A4JbHX0+RaTlp1sCoyJpc2qEg2/TiOA1Q==",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,12 @@ async function loadUser() {
   }
 }
 
-onMounted(loadUser)
+onMounted(() => {
+  // Initialize auth store from localStorage before loading user
+  // This restores the session if a valid token exists
+  authStore.initialize()
+  loadUser()
+})
 
 watch(() => authStore.isAuthenticated, loadUser)
 </script>

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { getCameras, getLayouts } from 'een-api-toolkit'
 import type { Camera, ListCamerasParams, EenError, Layout } from 'een-api-toolkit'
 import CameraCard from './CameraCard.vue'
+import ErrorCameraCard from './ErrorCameraCard.vue'
 
 const props = defineProps<{
   selectedCameraId: string | null
@@ -21,8 +22,12 @@ const totalSize = ref<number>(0)
 
 // Layout state
 const layouts = ref<Layout[]>([])
-const selectedLayoutId = ref<string>('all') // 'all' = All Cameras
+const selectedLayoutId = ref<string>('all') // 'all' = All Cameras, 'url' = URL-cameras
 const loadingLayouts = ref(false)
+
+// URL camera IDs state
+const urlCameraIds = ref<string[]>([])
+const inaccessibleCameraIds = ref<string[]>([]) // Camera IDs from URL that user cannot access
 
 // Pagination state - using dynamic calculation based on viewport
 const currentPage = ref(1)
@@ -60,12 +65,31 @@ const totalPages = computed(() => Math.ceil(totalSize.value / camerasPerPage.val
 const hasNextPage = computed(() => currentPage.value < totalPages.value)
 const hasPrevPage = computed(() => currentPage.value > 1)
 
-// Current page cameras (slice from loaded cameras or fetch specific page)
-const currentPageCameras = computed(() => {
+// Combined list of accessible cameras + inaccessible IDs for pagination
+type PageItem = { type: 'camera'; camera: Camera } | { type: 'error'; cameraId: string }
+
+const allPageItems = computed<PageItem[]>(() => {
+  const items: PageItem[] = []
+  // Add accessible cameras first
+  for (const camera of cameras.value) {
+    items.push({ type: 'camera', camera })
+  }
+  // Add inaccessible camera IDs as error items
+  for (const cameraId of inaccessibleCameraIds.value) {
+    items.push({ type: 'error', cameraId })
+  }
+  return items
+})
+
+// Current page items (slice from combined list)
+const currentPageItems = computed(() => {
   const start = (currentPage.value - 1) * camerasPerPage.value
   const end = start + camerasPerPage.value
-  return cameras.value.slice(start, end)
+  return allPageItems.value.slice(start, end)
 })
+
+// Check if URL cameras are configured
+const hasUrlCameras = computed(() => urlCameraIds.value.length > 0)
 
 // Fetch cameras from API
 async function fetchCameras(append = false) {
@@ -110,9 +134,28 @@ async function fetchLayouts() {
 
 // Apply layout filter to cameras
 function applyLayoutFilter() {
+  // Reset inaccessible cameras
+  inaccessibleCameraIds.value = []
+
   if (selectedLayoutId.value === 'all') {
     // Show all cameras
     cameras.value = [...allCameras.value]
+  } else if (selectedLayoutId.value === 'url') {
+    // Filter to only URL-specified cameras
+    const accessibleCameras: Camera[] = []
+    const inaccessible: string[] = []
+
+    for (const cameraId of urlCameraIds.value) {
+      const camera = allCameras.value.find(cam => cam.id === cameraId)
+      if (camera) {
+        accessibleCameras.push(camera)
+      } else {
+        inaccessible.push(cameraId)
+      }
+    }
+
+    cameras.value = accessibleCameras
+    inaccessibleCameraIds.value = inaccessible
   } else {
     // Find selected layout and filter cameras
     const layout = layouts.value.find(l => l.id === selectedLayoutId.value)
@@ -123,7 +166,9 @@ function applyLayoutFilter() {
       cameras.value = [...allCameras.value]
     }
   }
-  totalSize.value = cameras.value.length
+
+  // Total size includes accessible cameras + inaccessible error cards
+  totalSize.value = cameras.value.length + inaccessibleCameraIds.value.length
 
   // Check if current camera is in the filtered list
   const currentCameraId = props.selectedCameraId
@@ -199,6 +244,17 @@ function handleResize() {
 let resizeObserver: ResizeObserver | null = null
 
 onMounted(async () => {
+  // Check for URL camera IDs in sessionStorage
+  const storedCameraIds = sessionStorage.getItem('een_url_camera_ids')
+  if (storedCameraIds) {
+    // Parse comma-separated camera IDs
+    urlCameraIds.value = storedCameraIds.split(',').map(id => id.trim()).filter(id => id.length > 0)
+    // Auto-select "URL-cameras" if we have URL camera IDs
+    if (urlCameraIds.value.length > 0) {
+      selectedLayoutId.value = 'url'
+    }
+  }
+
   await fetchCameras()
 
   // Lazy load layouts after cameras are shown
@@ -237,6 +293,7 @@ onUnmounted(() => {
           class="text-sm font-semibold text-gray-700 bg-transparent border-none cursor-pointer hover:text-gray-900 focus:outline-none focus:ring-0 pr-6 -ml-1 max-w-[160px] truncate"
           title="Select layout"
         >
+          <option v-if="hasUrlCameras" value="url">URL-cameras</option>
           <option value="all">All Cameras</option>
           <option
             v-for="layout in layouts"
@@ -322,19 +379,25 @@ onUnmounted(() => {
       </div>
 
       <!-- No Cameras State -->
-      <div v-else-if="cameras.length === 0" class="p-4 text-center text-gray-500">
+      <div v-else-if="cameras.length === 0 && inaccessibleCameraIds.length === 0" class="p-4 text-center text-gray-500">
         <p class="text-sm">No cameras found</p>
       </div>
 
       <!-- Camera Cards Grid -->
       <div v-else class="p-3 space-y-3 h-full overflow-y-auto">
-        <CameraCard
-          v-for="camera in currentPageCameras"
-          :key="camera.id"
-          :camera="camera"
-          :selected="camera.id === selectedCameraId"
-          @select="handleCameraSelect"
-        />
+        <template v-for="item in currentPageItems" :key="item.type === 'camera' ? item.camera.id : item.cameraId">
+          <CameraCard
+            v-if="item.type === 'camera'"
+            :camera="item.camera"
+            :selected="item.camera.id === selectedCameraId"
+            @select="handleCameraSelect"
+          />
+          <ErrorCameraCard
+            v-else
+            :camera-id="item.cameraId"
+            error-message="No access to camera"
+          />
+        </template>
       </div>
     </div>
   </div>

--- a/src/components/ErrorCameraCard.vue
+++ b/src/components/ErrorCameraCard.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+defineProps<{
+  cameraId: string
+  errorMessage?: string
+}>()
+</script>
+
+<template>
+  <div
+    class="camera-card rounded-lg overflow-hidden border-2 border-red-300 bg-red-50"
+    :data-camera-id="cameraId"
+  >
+    <!-- Error Preview Area -->
+    <div class="relative aspect-video bg-red-100 flex items-center justify-center">
+      <div class="text-center p-2">
+        <svg
+          class="w-8 h-8 mx-auto text-red-400 mb-1"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <div class="text-red-600 text-xs font-medium">
+          {{ errorMessage || 'No access' }}
+        </div>
+      </div>
+
+      <!-- Error Badge -->
+      <div
+        class="absolute top-2 right-2 px-2 py-0.5 rounded-full bg-red-500 text-white text-xs font-medium"
+      >
+        error
+      </div>
+    </div>
+
+    <!-- Camera Info -->
+    <div class="p-2 bg-white border-t border-red-200">
+      <h3 class="text-sm font-medium text-red-700 truncate" :title="cameraId">
+        {{ cameraId }}
+      </h3>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.camera-card {
+  min-width: 0;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,6 +69,12 @@ router.beforeEach((to, _from, next) => {
     return
   }
 
+  // Capture URL camera IDs before redirecting to login
+  // Store them in sessionStorage so they persist through the OAuth flow but not across sessions
+  if (to.path === '/' && to.query.id) {
+    sessionStorage.setItem('een_url_camera_ids', to.query.id as string)
+  }
+
   if (to.meta.requiresAuth && !isAuthenticated()) {
     next({ name: 'login' })
   } else {


### PR DESCRIPTION
## Summary

- Add support for `?id=camera1,camera2` URL parameter to filter cameras by ID
- Store URL camera IDs in sessionStorage to persist through OAuth flow
- Add "URL-cameras" option to layout dropdown when URL cameras are specified
- Show error cards for cameras the user doesn't have access to
- Add `authStore.initialize()` call to properly hydrate auth state from localStorage
- Update een-api-toolkit to 0.3.43 and refresh agent definitions

## Test plan

- [ ] Navigate to app with `?id=<valid_camera_id>` - should show "URL-cameras" in dropdown and filter to that camera
- [ ] Navigate with invalid camera ID - should show error card with "No access to camera"
- [ ] Verify login persists across page refresh (no re-login required)
- [ ] Verify switching between "URL-cameras", "All Cameras", and layouts works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)