### PR TITLE
Add bounding box visualization, HLS seeking, and UI improvements

### DIFF
--- a/src/components/BoundingBoxOverlay.vue
+++ b/src/components/BoundingBoxOverlay.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import type { BoundingBox } from '@/composables/useBoundingBoxes'
+
+const props = defineProps<{
+  boxes: BoundingBox[]
+  showLabels?: boolean  // Show labels on larger previews
+  thin?: boolean        // Use thinner stroke for large video overlays
+  isDark?: boolean
+}>()
+
+// Color palette for different object types
+function getBoxColor(label: string): string {
+  const labelLower = label.toLowerCase()
+  if (labelLower === 'person' || labelLower === 'human') return '#ef4444' // red
+  if (labelLower === 'vehicle' || labelLower === 'car' || labelLower === 'truck') return '#3b82f6' // blue
+  if (labelLower === 'animal' || labelLower === 'dog' || labelLower === 'cat') return '#22c55e' // green
+  return '#f59e0b' // amber for other/unknown
+}
+
+// Stroke width - thinner for large video overlays
+const strokeWidth = props.thin ? 0.25 : 0.5
+
+// Font size - smaller for large video overlays
+const fontSize = props.thin ? 2.1 : 3
+const labelHeight = props.thin ? 2.8 : 4
+const labelYOffset = props.thin ? 2.8 : 4
+const textYOffset = props.thin ? 2.1 : 3
+</script>
+
+<template>
+  <svg
+    class="absolute inset-0 w-full h-full pointer-events-none"
+    viewBox="0 0 100 100"
+    preserveAspectRatio="none"
+  >
+    <g v-for="box in boxes" :key="box.objectId">
+      <!-- Bounding box rectangle -->
+      <rect
+        :x="box.x * 100"
+        :y="box.y * 100"
+        :width="box.width * 100"
+        :height="box.height * 100"
+        :stroke="getBoxColor(box.label)"
+        :stroke-width="strokeWidth"
+        fill="none"
+      />
+      <!-- Label background (only for larger previews) -->
+      <rect
+        v-if="showLabels"
+        :x="box.x * 100"
+        :y="Math.max(0, box.y * 100 - labelYOffset)"
+        :width="Math.max(12, Math.min(20, box.width * 100))"
+        :height="labelHeight"
+        :fill="getBoxColor(box.label)"
+        opacity="0.9"
+      />
+      <!-- Label text (only for larger previews) -->
+      <text
+        v-if="showLabels"
+        :x="box.x * 100 + 0.5"
+        :y="Math.max(textYOffset, box.y * 100 - 0.7)"
+        fill="white"
+        :font-size="fontSize"
+        font-family="system-ui, sans-serif"
+        font-weight="600"
+      >
+        {{ box.label }}
+      </text>
+    </g>
+  </svg>
+</template>

--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -4,6 +4,8 @@ import { listEvents, listEventTypes } from 'een-api-toolkit'
 import type { Camera, Event, EenError } from 'een-api-toolkit'
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
+import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
+import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
   camera: Camera | null
@@ -14,7 +16,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'events-refreshed', eventTimestamps: string[]): void
-  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string }): void
+  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }): void
 }>()
 
 // Use shared image cache
@@ -32,6 +34,7 @@ const eventTypeNames = ref<Map<string, string>>(new Map())
 const hoveredEventId = ref<string | null>(null)
 const hoverPosition = ref<{ bottom: number; right: number } | null>(null)
 const isAtTop = ref(true)
+const boundingBoxesMap = ref<Map<string, BoundingBox[]>>(new Map())
 
 // Auto-refresh state
 const autoRefresh = ref(false)
@@ -127,7 +130,11 @@ async function fetchEvents(append = false) {
     pageSize: 20,
     pageToken: append ? nextPageToken.value : undefined,
     sort: '-startTimestamp',
-    include: ['data.een.fullFrameImageUrl.v1']
+    include: [
+      'data.een.fullFrameImageUrl.v1',
+      'data.een.objectDetection.v1',
+      'data.een.objectClassification.v1'
+    ]
   })
 
   if (result.error) {
@@ -143,6 +150,7 @@ async function fetchEvents(append = false) {
     } else {
       events.value = newEvents
       clearImages()
+      boundingBoxesMap.value.clear()
       // Emit event timestamps so live events can filter out duplicates
       emit('events-refreshed', newEvents.map(e => e.startTimestamp))
       // Scroll to top on refresh
@@ -150,8 +158,9 @@ async function fetchEvents(append = false) {
     }
     nextPageToken.value = result.data.nextPageToken
 
-    // Load images for the new events
+    // Load images and extract bounding boxes for the new events
     loadEventImages(newEvents)
+    extractEventBoundingBoxes(newEvents)
   }
 
   loading.value = false
@@ -168,6 +177,21 @@ async function loadEventImages(eventsToLoad: Event[]) {
 // Get image for an event
 function getEventImage(event: Event): string | null {
   return getImage(event.id)
+}
+
+// Extract and store bounding boxes for events
+function extractEventBoundingBoxes(eventsToProcess: Event[]) {
+  for (const event of eventsToProcess) {
+    const boxes = extractBoundingBoxes(event)
+    if (boxes.length > 0) {
+      boundingBoxesMap.value.set(event.id, boxes)
+    }
+  }
+}
+
+// Get bounding boxes for an event
+function getBoundingBoxes(eventId: string): BoundingBox[] {
+  return boundingBoxesMap.value.get(eventId) || []
 }
 
 // Handle thumbnail hover - capture position for popup
@@ -193,7 +217,8 @@ function handleEventClick(event: Event) {
     cameraId: event.actorId,
     timestamp: event.startTimestamp,
     eventType: getEventTypeName(event.type),
-    eventId: event.id
+    eventId: event.id,
+    boundingBoxes: getBoundingBoxes(event.id)
   })
 }
 
@@ -360,7 +385,7 @@ watch(
       >
         <!-- Thumbnail -->
         <div
-          class="w-12 h-8 rounded overflow-hidden flex-shrink-0"
+          class="w-12 h-8 rounded overflow-hidden flex-shrink-0 relative"
           :class="isDark ? 'bg-gray-700' : 'bg-gray-200'"
           @mouseenter="handleThumbnailHover(event, $event)"
           @mouseleave="clearHover"
@@ -371,7 +396,12 @@ watch(
             :alt="event.type"
             class="w-full h-full object-cover cursor-pointer"
           />
-          <div v-else class="w-full h-full flex items-center justify-center">
+          <BoundingBoxOverlay
+            v-if="getEventImage(event) && getBoundingBoxes(event.id).length > 0"
+            :boxes="getBoundingBoxes(event.id)"
+            :isDark="isDark"
+          />
+          <div v-if="!getEventImage(event)" class="w-full h-full flex items-center justify-center">
             <svg class="w-4 h-4" :class="isDark ? 'text-gray-500' : 'text-gray-400'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
@@ -402,11 +432,19 @@ watch(
             transform: 'translateX(-100%) translateY(-100%)'
           }"
         >
-          <img
-            :src="getImage(hoveredEventId) || ''"
-            alt="Event preview"
-            class="max-w-[384px] h-auto rounded"
-          />
+          <div class="relative">
+            <img
+              :src="getImage(hoveredEventId) || ''"
+              alt="Event preview"
+              class="max-w-[384px] h-auto rounded"
+            />
+            <BoundingBoxOverlay
+              v-if="getBoundingBoxes(hoveredEventId).length > 0"
+              :boxes="getBoundingBoxes(hoveredEventId)"
+              :showLabels="true"
+              :isDark="isDark"
+            />
+          </div>
         </div>
       </Teleport>
 

--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -9,6 +9,8 @@ import {
 import type { Camera, EenError, SSEEvent, SSEConnection, SSEConnectionStatus } from 'een-api-toolkit'
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
+import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
+import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
   camera: Camera | null
@@ -18,7 +20,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string }): void
+  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }): void
 }>()
 
 // Use shared image cache
@@ -37,6 +39,7 @@ const eventTypeNames = ref<Map<string, string>>(new Map())
 const autoScroll = ref(true)
 const autoReconnect = ref(false)
 const hoveredEventId = ref<string | null>(null)
+const boundingBoxesMap = ref<Map<string, BoundingBox[]>>(new Map())
 
 // Reconnection timer (SSE subscriptions expire after 15 minutes)
 const SUBSCRIPTION_TTL_MS = 14 * 60 * 1000 // Reconnect at 14 minutes (before 15 min expiry)
@@ -122,6 +125,12 @@ function handleEvent(event: SSEEvent) {
     loadImage(event.id, event.actorId, event.startTimestamp)
   }
 
+  // Extract bounding boxes if present
+  const boxes = extractBoundingBoxes(event)
+  if (boxes.length > 0) {
+    boundingBoxesMap.value.set(event.id, boxes)
+  }
+
   // Trim to max events
   if (events.value.length > MAX_EVENTS) {
     events.value = events.value.slice(0, MAX_EVENTS)
@@ -136,6 +145,11 @@ function handleEvent(event: SSEEvent) {
 // Get image for an event
 function getEventImage(event: SSEEvent): string | null {
   return getImage(event.id)
+}
+
+// Get bounding boxes for an event
+function getBoundingBoxes(eventId: string): BoundingBox[] {
+  return boundingBoxesMap.value.get(eventId) || []
 }
 
 // Handle thumbnail hover - capture position for popup
@@ -161,7 +175,8 @@ function handleEventClick(event: SSEEvent) {
     cameraId: event.actorId,
     timestamp: event.startTimestamp,
     eventType: getEventTypeName(event.type),
-    eventId: event.id
+    eventId: event.id,
+    boundingBoxes: getBoundingBoxes(event.id)
   })
 }
 
@@ -273,6 +288,7 @@ async function connect() {
   connectionError.value = null
   events.value = []
   clearImages() // Clear images to prevent showing thumbnails from previous camera
+  boundingBoxesMap.value.clear() // Clear bounding boxes from previous camera
 
   await createAndConnectSubscription(currentAttemptId)
 }
@@ -386,6 +402,7 @@ async function disconnect() {
 function clearEvents() {
   events.value = []
   clearImages()
+  boundingBoxesMap.value.clear()
 }
 
 // Remove events by timestamps (called when historic events are refreshed)
@@ -582,7 +599,7 @@ onUnmounted(async () => {
       >
         <!-- Thumbnail -->
         <div
-          class="w-12 h-8 rounded overflow-hidden flex-shrink-0"
+          class="w-12 h-8 rounded overflow-hidden flex-shrink-0 relative"
           :class="isDark ? 'bg-gray-700' : 'bg-gray-200'"
           @mouseenter="handleThumbnailHover(event, $event)"
           @mouseleave="clearHover"
@@ -593,7 +610,12 @@ onUnmounted(async () => {
             :alt="event.type"
             class="w-full h-full object-cover cursor-pointer"
           />
-          <div v-else class="w-full h-full flex items-center justify-center">
+          <BoundingBoxOverlay
+            v-if="getEventImage(event) && getBoundingBoxes(event.id).length > 0"
+            :boxes="getBoundingBoxes(event.id)"
+            :isDark="isDark"
+          />
+          <div v-if="!getEventImage(event)" class="w-full h-full flex items-center justify-center">
             <svg class="w-4 h-4" :class="isDark ? 'text-gray-500' : 'text-gray-400'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
@@ -624,11 +646,19 @@ onUnmounted(async () => {
             transform: 'translateX(-100%) translateY(-100%)'
           }"
         >
-          <img
-            :src="getImage(hoveredEventId) || ''"
-            alt="Event preview"
-            class="max-w-[384px] h-auto rounded"
-          />
+          <div class="relative">
+            <img
+              :src="getImage(hoveredEventId) || ''"
+              alt="Event preview"
+              class="max-w-[384px] h-auto rounded"
+            />
+            <BoundingBoxOverlay
+              v-if="getBoundingBoxes(hoveredEventId).length > 0"
+              :boxes="getBoundingBoxes(hoveredEventId)"
+              :showLabels="true"
+              :isDark="isDark"
+            />
+          </div>
         </div>
       </Teleport>
     </div>

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -4,12 +4,15 @@ import { useAuthStore } from 'een-api-toolkit'
 import type { Camera, CameraStatus } from 'een-api-toolkit'
 import LivePlayer from '@een/live-video-web-sdk'
 import { useHlsPlayer } from '@/composables/useHlsPlayer'
+import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
+import type { BoundingBox } from '@/composables/useBoundingBoxes'
 
 const props = defineProps<{
   camera: Camera
   playbackMode?: 'live' | 'recorded'
   playbackTimestamp?: string | null
   playbackEventType?: string | null
+  playbackBoundingBoxes?: BoundingBox[]
   isDark?: boolean
 }>()
 
@@ -392,7 +395,7 @@ onUnmounted(() => {
 
         <!-- HLS Video Element -->
         <div
-          class="video-wrapper w-full h-full"
+          class="video-wrapper w-full h-full relative"
           :class="{ 'video-hidden': hlsPlayer.loadingVideo.value || hlsPlayer.videoError.value }"
         >
           <video
@@ -403,6 +406,15 @@ onUnmounted(() => {
             autoplay
             muted
             playsinline
+          />
+          <!-- Bounding Box Overlay (shown only when paused) -->
+          <BoundingBoxOverlay
+            v-if="!isHlsPlaying && playbackBoundingBoxes && playbackBoundingBoxes.length > 0"
+            :boxes="playbackBoundingBoxes"
+            :showLabels="true"
+            :thin="true"
+            :isDark="isDark"
+            class="absolute inset-0 pointer-events-none"
           />
         </div>
 

--- a/src/composables/useBoundingBoxes.ts
+++ b/src/composables/useBoundingBoxes.ts
@@ -1,0 +1,94 @@
+import type { Event, SSEEvent } from 'een-api-toolkit'
+
+export interface BoundingBox {
+  x: number      // Normalized 0-1 (left)
+  y: number      // Normalized 0-1 (top)
+  width: number  // Normalized 0-1
+  height: number // Normalized 0-1
+  label: string  // Object classification label
+  objectId: string
+}
+
+interface ObjectDetectionData {
+  type: 'een.objectDetection.v1'
+  creatorId: string
+  boundingBox: [number, number, number, number] // [x1, y1, x2, y2]
+  objectId: string
+}
+
+interface ObjectClassificationData {
+  type: 'een.objectClassification.v1'
+  creatorId: string
+  objectId: string
+  label: string
+  confidence?: number
+}
+
+type EventData = ObjectDetectionData | ObjectClassificationData | { type: string }
+
+/**
+ * Infer label from event type when classification data is not available
+ */
+function inferLabelFromEventType(eventType: string): string {
+  const typeLower = eventType.toLowerCase()
+  if (typeLower.includes('person')) return 'Person'
+  if (typeLower.includes('vehicle')) return 'Vehicle'
+  if (typeLower.includes('animal')) return 'Animal'
+  if (typeLower.includes('motion')) return 'Motion'
+  return 'Object'
+}
+
+/**
+ * Extract bounding boxes from event data
+ * Combines objectDetection (coordinates) with objectClassification (labels)
+ * Falls back to inferring label from event type if classification is not available
+ */
+export function extractBoundingBoxes(event: Event | SSEEvent): BoundingBox[] {
+  const boxes: BoundingBox[] = []
+
+  if (!event.data || !Array.isArray(event.data)) {
+    return boxes
+  }
+
+  // Build classification map: objectId -> label
+  const classificationMap = new Map<string, string>()
+  for (const dataItem of event.data as EventData[]) {
+    if (dataItem.type === 'een.objectClassification.v1') {
+      const classification = dataItem as ObjectClassificationData
+      classificationMap.set(classification.objectId, classification.label)
+    }
+  }
+
+  // Fallback label from event type
+  const fallbackLabel = inferLabelFromEventType(event.type)
+
+  // Extract bounding boxes and attach labels
+  for (const dataItem of event.data as EventData[]) {
+    if (dataItem.type === 'een.objectDetection.v1') {
+      const detection = dataItem as ObjectDetectionData
+      const [x1, y1, x2, y2] = detection.boundingBox
+
+      boxes.push({
+        x: x1,
+        y: y1,
+        width: x2 - x1,
+        height: y2 - y1,
+        label: classificationMap.get(detection.objectId) || fallbackLabel,
+        objectId: detection.objectId
+      })
+    }
+  }
+
+  return boxes
+}
+
+/**
+ * Check if an event has bounding box data
+ */
+export function hasBoundingBoxes(event: Event | SSEEvent): boolean {
+  if (!event.data || !Array.isArray(event.data)) {
+    return false
+  }
+
+  return event.data.some((d: EventData) => d.type === 'een.objectDetection.v1')
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,6 +9,7 @@ import MainVideoPlayer from '../components/MainVideoPlayer.vue'
 import EventTypesPanel from '../components/EventTypesPanel.vue'
 import HistoricEventsPanel from '../components/HistoricEventsPanel.vue'
 import LiveEventsPanel from '../components/LiveEventsPanel.vue'
+import type { BoundingBox } from '@/composables/useBoundingBoxes'
 
 // Inject dark mode state
 const isDark = inject<Ref<boolean>>('isDark', ref(false))
@@ -55,6 +56,7 @@ const playbackMode = ref<'live' | 'recorded'>('live')
 const playbackTimestamp = ref<string | null>(null)
 const playbackEventType = ref<string | null>(null)
 const playbackEventId = ref<string | null>(null)
+const playbackBoundingBoxes = ref<BoundingBox[]>([])
 
 // Computed selected camera ID for sidebar
 const selectedCameraId = computed(() => selectedCamera.value?.id || null)
@@ -67,14 +69,16 @@ function handleCameraSelect(camera: Camera) {
   playbackTimestamp.value = null
   playbackEventType.value = null
   playbackEventId.value = null
+  playbackBoundingBoxes.value = []
 }
 
 // Handle event click - switch to recorded playback
-function handleEventClick(event: { cameraId: string; timestamp: string; eventType: string; eventId: string }) {
+function handleEventClick(event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }) {
   playbackMode.value = 'recorded'
   playbackTimestamp.value = event.timestamp
   playbackEventType.value = event.eventType
   playbackEventId.value = event.eventId
+  playbackBoundingBoxes.value = event.boundingBoxes
 }
 
 // Selected event types state (shared between panels)
@@ -144,6 +148,7 @@ onMounted(async () => {
               :playback-mode="playbackMode"
               :playback-timestamp="playbackTimestamp"
               :playback-event-type="playbackEventType"
+              :playback-bounding-boxes="playbackBoundingBoxes"
               :is-dark="isDark"
             />
           </div>


### PR DESCRIPTION
## Summary

- **Bounding Box Visualization**: Display object detection boxes on event thumbnails, hover previews, and paused HLS video
- **HLS Timestamp Seeking**: Recorded video seeks to exact event timestamp when clicked
- **Event Playback Controls**: Click event card to play/pause and seek back to event start
- **Dark Mode**: Toggle between light and dark themes with persistent preference
- **URL Camera Sync**: Camera ID automatically updates in URL for shareable links
- **Visual Feedback**: Orange borders for playing cameras/active events, improved selection states
- **Eye Favicon**: New eye-themed favicon representing "observation"
- **SSE Improvements**: Fixed race conditions and improved reconnection handling

## Files Changed

- 23+ files modified with new features and UI improvements
- New components: `BoundingBoxOverlay.vue`, `ErrorCameraCard.vue`
- New composables: `useBoundingBoxes.ts`, `useDarkMode.ts`
- Updated README with comprehensive feature documentation

## Test plan

- [ ] Verify bounding boxes appear on Person Detection event thumbnails
- [ ] Hover over thumbnail to see enlarged preview with labeled bounding boxes
- [ ] Click event to play HLS video, pause to see bounding box overlay
- [ ] Verify dark mode toggle works and persists
- [ ] Select camera and verify URL updates with camera ID
- [ ] Test SSE reconnection by toggling network

🤖 Generated with [Claude Code](https://claude.com/claude-code)