### PR TITLE
Fix bounding box alignment for letterboxed video

### DIFF
--- a/src/components/BoundingBoxOverlay.vue
+++ b/src/components/BoundingBoxOverlay.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import type { BoundingBox } from '@/composables/useBoundingBoxes'
 
 const props = defineProps<{
@@ -6,7 +7,136 @@ const props = defineProps<{
   showLabels?: boolean  // Show labels on larger previews
   thin?: boolean        // Use thinner stroke for large video overlays
   isDark?: boolean
+  videoElement?: HTMLVideoElement | null  // Video element for letterbox calculation
 }>()
+
+// Computed dimensions for positioning overlay correctly on letterboxed video
+const overlayStyle = ref({
+  left: '0px',
+  top: '0px',
+  width: '100%',
+  height: '100%'
+})
+
+// Calculate the actual video display area within the container (accounting for letterboxing)
+function updateOverlayPosition() {
+  const video = props.videoElement
+  if (!video) {
+    // Fallback: fill container (for thumbnails/images without letterboxing)
+    overlayStyle.value = { left: '0px', top: '0px', width: '100%', height: '100%' }
+    return
+  }
+
+  // Get the video's natural dimensions
+  const videoWidth = video.videoWidth
+  const videoHeight = video.videoHeight
+
+  if (!videoWidth || !videoHeight) {
+    // Video metadata not loaded yet
+    overlayStyle.value = { left: '0px', top: '0px', width: '100%', height: '100%' }
+    return
+  }
+
+  // Get the container dimensions (the space the video element occupies)
+  const containerWidth = video.clientWidth
+  const containerHeight = video.clientHeight
+
+  if (!containerWidth || !containerHeight) {
+    overlayStyle.value = { left: '0px', top: '0px', width: '100%', height: '100%' }
+    return
+  }
+
+  // Calculate the aspect ratios
+  const videoAspectRatio = videoWidth / videoHeight
+  const containerAspectRatio = containerWidth / containerHeight
+
+  let displayWidth: number
+  let displayHeight: number
+  let offsetLeft: number
+  let offsetTop: number
+
+  if (videoAspectRatio > containerAspectRatio) {
+    // Video is wider than container - black bars on top and bottom
+    displayWidth = containerWidth
+    displayHeight = containerWidth / videoAspectRatio
+    offsetLeft = 0
+    offsetTop = (containerHeight - displayHeight) / 2
+  } else {
+    // Video is taller than container - black bars on left and right
+    displayHeight = containerHeight
+    displayWidth = containerHeight * videoAspectRatio
+    offsetLeft = (containerWidth - displayWidth) / 2
+    offsetTop = 0
+  }
+
+  overlayStyle.value = {
+    left: `${offsetLeft}px`,
+    top: `${offsetTop}px`,
+    width: `${displayWidth}px`,
+    height: `${displayHeight}px`
+  }
+}
+
+// Watch for video element changes and set up event listeners
+let resizeObserver: ResizeObserver | null = null
+
+function setupVideoListeners() {
+  const video = props.videoElement
+  if (!video) return
+
+  // Update on loadedmetadata (when video dimensions become available)
+  video.addEventListener('loadedmetadata', updateOverlayPosition)
+
+  // Update on resize of the video element
+  resizeObserver = new ResizeObserver(() => {
+    updateOverlayPosition()
+  })
+  resizeObserver.observe(video)
+
+  // Initial update
+  updateOverlayPosition()
+}
+
+function cleanupVideoListeners() {
+  const video = props.videoElement
+  if (video) {
+    video.removeEventListener('loadedmetadata', updateOverlayPosition)
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+}
+
+watch(() => props.videoElement, (newVideo, oldVideo) => {
+  if (oldVideo) {
+    oldVideo.removeEventListener('loadedmetadata', updateOverlayPosition)
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+  if (newVideo) {
+    setupVideoListeners()
+  } else {
+    overlayStyle.value = { left: '0px', top: '0px', width: '100%', height: '100%' }
+  }
+}, { immediate: true })
+
+// Also watch for box changes to trigger recalculation
+watch(() => props.boxes, () => {
+  nextTick(() => updateOverlayPosition())
+}, { deep: true })
+
+onMounted(() => {
+  if (props.videoElement) {
+    setupVideoListeners()
+  }
+})
+
+onUnmounted(() => {
+  cleanupVideoListeners()
+})
 
 // Color palette for different object types
 function getBoxColor(label: string): string {
@@ -29,7 +159,8 @@ const textYOffset = props.thin ? 2.1 : 3
 
 <template>
   <svg
-    class="absolute inset-0 w-full h-full pointer-events-none"
+    class="absolute pointer-events-none"
+    :style="overlayStyle"
     viewBox="0 0 100 100"
     preserveAspectRatio="none"
   >

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -414,7 +414,7 @@ onUnmounted(() => {
             :showLabels="true"
             :thin="true"
             :isDark="isDark"
-            class="absolute inset-0 pointer-events-none"
+            :videoElement="hlsPlayer.videoRef.value"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Fix bounding box overlay positioning for videos with letterboxing (black bars)
- Calculate actual video display area within container based on aspect ratio
- Position SVG overlay to match video content area instead of full container

## Test plan
- [ ] Play recorded video with different aspect ratio than container
- [ ] Verify bounding boxes align with detected objects in video content
- [ ] Confirm overlay doesn't extend into black bar areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)