### PR TITLE
Add event data modal with info button

### DIFF
--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'events-refreshed', eventTimestamps: string[]): void
-  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }): void
+  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[]; eventData: unknown[] }): void
 }>()
 
 // Use shared image cache
@@ -218,7 +218,8 @@ function handleEventClick(event: Event) {
     timestamp: event.startTimestamp,
     eventType: getEventTypeName(event.type),
     eventId: event.id,
-    boundingBoxes: getBoundingBoxes(event.id)
+    boundingBoxes: getBoundingBoxes(event.id),
+    eventData: event.data || []
   })
 }
 

--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }): void
+  (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[]; eventData: unknown[] }): void
 }>()
 
 // Use shared image cache
@@ -176,7 +176,8 @@ function handleEventClick(event: SSEEvent) {
     timestamp: event.startTimestamp,
     eventType: getEventTypeName(event.type),
     eventId: event.id,
-    boundingBoxes: getBoundingBoxes(event.id)
+    boundingBoxes: getBoundingBoxes(event.id),
+    eventData: event.data || []
   })
 }
 

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   playbackTimestamp?: string | null
   playbackEventType?: string | null
   playbackBoundingBoxes?: BoundingBox[]
+  playbackEventData?: unknown[]
   isDark?: boolean
 }>()
 
@@ -39,6 +40,9 @@ const isMounted = ref(true)
 
 // HLS playback state
 const isHlsPlaying = ref(true) // Assume playing initially since autoplay is enabled
+
+// Event data modal state
+const showEventDataModal = ref(false)
 
 // Helper to extract status string from the union type
 function getStatusString(status?: CameraStatus | { connectionStatus?: CameraStatus }): CameraStatus | undefined {
@@ -486,7 +490,19 @@ onUnmounted(() => {
               </svg>
             </div>
           </div>
-          <p :class="isDark ? 'text-orange-400' : 'text-orange-600'" class="text-sm mt-1 font-medium">{{ formattedPlaybackTimestamp }}</p>
+          <div class="flex items-center justify-between mt-1">
+            <p :class="isDark ? 'text-orange-400' : 'text-orange-600'" class="text-sm font-medium">{{ formattedPlaybackTimestamp }}</p>
+            <!-- Info Icon -->
+            <button
+              v-if="playbackEventData && playbackEventData.length > 0"
+              @click.stop="showEventDataModal = true"
+              class="w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold border transition-colors"
+              :class="isDark ? 'border-orange-400 text-orange-400 hover:bg-orange-400 hover:text-gray-900' : 'border-orange-600 text-orange-600 hover:bg-orange-600 hover:text-white'"
+              title="View event data"
+            >
+              i
+            </button>
+          </div>
         </div>
 
         <!-- Location ID (if available) -->
@@ -520,6 +536,47 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+
+    <!-- Event Data Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showEventDataModal"
+        class="fixed inset-0 z-50 flex items-center justify-center"
+        @click.self="showEventDataModal = false"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/50" @click="showEventDataModal = false" />
+
+        <!-- Modal -->
+        <div
+          class="relative rounded-lg shadow-xl max-h-[80vh] flex flex-col"
+          :class="isDark ? 'bg-gray-800' : 'bg-white'"
+          style="width: 80%"
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between p-4 border-b" :class="isDark ? 'border-gray-700' : 'border-gray-200'">
+            <h3 class="text-lg font-semibold" :class="isDark ? 'text-white' : 'text-gray-800'">Event Data</h3>
+            <button
+              @click="showEventDataModal = false"
+              class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+              :class="isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-800'"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Content -->
+          <div class="p-4 overflow-auto flex-1">
+            <pre
+              class="text-xs font-mono p-4 rounded overflow-auto"
+              :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
+            >{{ JSON.stringify(playbackEventData, null, 2) }}</pre>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -57,6 +57,7 @@ const playbackTimestamp = ref<string | null>(null)
 const playbackEventType = ref<string | null>(null)
 const playbackEventId = ref<string | null>(null)
 const playbackBoundingBoxes = ref<BoundingBox[]>([])
+const playbackEventData = ref<unknown[]>([])
 
 // Computed selected camera ID for sidebar
 const selectedCameraId = computed(() => selectedCamera.value?.id || null)
@@ -70,15 +71,17 @@ function handleCameraSelect(camera: Camera) {
   playbackEventType.value = null
   playbackEventId.value = null
   playbackBoundingBoxes.value = []
+  playbackEventData.value = []
 }
 
 // Handle event click - switch to recorded playback
-function handleEventClick(event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[] }) {
+function handleEventClick(event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[]; eventData: unknown[] }) {
   playbackMode.value = 'recorded'
   playbackTimestamp.value = event.timestamp
   playbackEventType.value = event.eventType
   playbackEventId.value = event.eventId
   playbackBoundingBoxes.value = event.boundingBoxes
+  playbackEventData.value = event.eventData
 }
 
 // Selected event types state (shared between panels)
@@ -149,6 +152,7 @@ onMounted(async () => {
               :playback-timestamp="playbackTimestamp"
               :playback-event-type="playbackEventType"
               :playback-bounding-boxes="playbackBoundingBoxes"
+              :playback-event-data="playbackEventData"
               :is-dark="isDark"
             />
           </div>


### PR DESCRIPTION
## Summary
- Pass event metadata (data section) through component chain to MainVideoPlayer
- Add info (i) button next to event timestamp when event data is available
- Display raw JSON event data in an 80% width modal dialog

## Test plan
- [ ] Click on an event with metadata to trigger recorded playback
- [ ] Verify (i) button appears next to the timestamp
- [ ] Click (i) button and verify modal shows raw JSON data
- [ ] Verify modal closes when clicking X or backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)