### PR TITLE
Enhance event playback with duration and smart bounding boxes

### DIFF
--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -40,6 +40,15 @@ const isMounted = ref(true)
 
 // HLS playback state
 const isHlsPlaying = ref(true) // Assume playing initially since autoplay is enabled
+const currentVideoTime = ref(0) // Track current video time for bounding box display
+
+// Check if video is at event timestamp (within tolerance)
+const BOUNDING_BOX_TOLERANCE = 0.5 // seconds
+const isAtEventTimestamp = computed(() => {
+  if (isHlsPlaying.value) return false
+  const eventOffset = hlsPlayer.eventStartOffset.value
+  return Math.abs(currentVideoTime.value - eventOffset) <= BOUNDING_BOX_TOLERANCE
+})
 
 // Event data modal state
 const showEventDataModal = ref(false)
@@ -176,6 +185,7 @@ function handleEventCardClick() {
     } else {
       video.pause()
       isHlsPlaying.value = false
+      currentVideoTime.value = video.currentTime
     }
   }
 }
@@ -190,6 +200,7 @@ function setupVideoEventListeners() {
   })
   video.addEventListener('pause', () => {
     isHlsPlaying.value = false
+    currentVideoTime.value = video.currentTime
   })
 }
 
@@ -478,9 +489,9 @@ onUnmounted(() => {
             muted
             playsinline
           />
-          <!-- Bounding Box Overlay (shown only when paused) -->
+          <!-- Bounding Box Overlay (shown only when paused at event timestamp) -->
           <BoundingBoxOverlay
-            v-if="!isHlsPlaying && playbackBoundingBoxes && playbackBoundingBoxes.length > 0"
+            v-if="isAtEventTimestamp && playbackBoundingBoxes && playbackBoundingBoxes.length > 0"
             :boxes="playbackBoundingBoxes"
             :showLabels="true"
             :thin="true"

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -42,12 +42,33 @@ const isMounted = ref(true)
 const isHlsPlaying = ref(true) // Assume playing initially since autoplay is enabled
 const currentVideoTime = ref(0) // Track current video time for bounding box display
 
-// Check if video is at event timestamp (within tolerance)
-const BOUNDING_BOX_TOLERANCE = 0.5 // seconds
-const isAtEventTimestamp = computed(() => {
-  if (isHlsPlaying.value) return false
-  const eventOffset = hlsPlayer.eventStartOffset.value
-  return Math.abs(currentVideoTime.value - eventOffset) <= BOUNDING_BOX_TOLERANCE
+// Calculate event end offset from event object timestamps
+const eventEndOffset = computed(() => {
+  if (!props.playbackEventObject) return 0
+
+  const startTimestamp = props.playbackEventObject.startTimestamp as string | undefined
+  const endTimestamp = props.playbackEventObject.endTimestamp as string | undefined
+
+  if (!startTimestamp || !endTimestamp) return hlsPlayer.eventStartOffset.value
+
+  const startMs = new Date(startTimestamp).getTime()
+  const endMs = new Date(endTimestamp).getTime()
+  const durationSeconds = (endMs - startMs) / 1000
+
+  // Event end offset = event start offset + duration
+  return hlsPlayer.eventStartOffset.value + durationSeconds
+})
+
+// Check if video is within event time range (between start and end timestamps)
+const BOUNDING_BOX_TOLERANCE = 0.25 // seconds tolerance at boundaries
+const isWithinEventTimeRange = computed(() => {
+  const startOffset = hlsPlayer.eventStartOffset.value
+  const endOffset = eventEndOffset.value
+  const currentTime = currentVideoTime.value
+
+  // Check if current time is within the event range (with tolerance at boundaries)
+  return currentTime >= (startOffset - BOUNDING_BOX_TOLERANCE) &&
+         currentTime <= (endOffset + BOUNDING_BOX_TOLERANCE)
 })
 
 // Event data modal state
@@ -200,6 +221,10 @@ function setupVideoEventListeners() {
   })
   video.addEventListener('pause', () => {
     isHlsPlaying.value = false
+    currentVideoTime.value = video.currentTime
+  })
+  // Track video position continuously for bounding box display
+  video.addEventListener('timeupdate', () => {
     currentVideoTime.value = video.currentTime
   })
 }
@@ -489,9 +514,9 @@ onUnmounted(() => {
             muted
             playsinline
           />
-          <!-- Bounding Box Overlay (shown only when paused at event timestamp) -->
+          <!-- Bounding Box Overlay (shown when video is within event time range) -->
           <BoundingBoxOverlay
-            v-if="isAtEventTimestamp && playbackBoundingBoxes && playbackBoundingBoxes.length > 0"
+            v-if="isWithinEventTimeRange && playbackBoundingBoxes && playbackBoundingBoxes.length > 0"
             :boxes="playbackBoundingBoxes"
             :showLabels="true"
             :thin="true"

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -125,6 +125,41 @@ const formattedPlaybackTimestamp = computed(() => {
   })
 })
 
+// Calculate event duration from startTimestamp and endTimestamp
+const eventDuration = computed(() => {
+  if (!props.playbackEventObject) return null
+
+  const startTimestamp = props.playbackEventObject.startTimestamp as string | undefined
+  const endTimestamp = props.playbackEventObject.endTimestamp as string | undefined
+
+  if (!startTimestamp || !endTimestamp) return null
+
+  const startMs = new Date(startTimestamp).getTime()
+  const endMs = new Date(endTimestamp).getTime()
+  const diffMs = endMs - startMs
+
+  // Return null if timestamps are the same or invalid
+  if (diffMs <= 0) return null
+
+  const seconds = Math.floor(diffMs / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (seconds < 60) {
+    return `${seconds}s`
+  } else if (minutes < 60) {
+    const remainingSeconds = seconds % 60
+    return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+  } else if (hours < 24) {
+    const remainingMinutes = minutes % 60
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+  } else {
+    const remainingHours = hours % 24
+    return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`
+  }
+})
+
 // Handle event card click - seek to timestamp and toggle play/pause
 function handleEventCardClick() {
   const video = hlsPlayer.videoRef.value
@@ -534,6 +569,10 @@ onUnmounted(() => {
             >
               i
             </button>
+          </div>
+          <!-- Event Duration -->
+          <div v-if="eventDuration" class="mt-1">
+            <span :class="isDark ? 'text-orange-400/70' : 'text-orange-600/70'" class="text-xs">Duration: {{ eventDuration }}</span>
           </div>
         </div>
 

--- a/src/composables/useHlsPlayer.ts
+++ b/src/composables/useHlsPlayer.ts
@@ -9,6 +9,7 @@ export interface HlsPlayerReturn {
   videoError: Ref<string | null>
   loadingVideo: Ref<boolean>
   videoRef: Ref<HTMLVideoElement | null>
+  eventStartOffset: Ref<number>
   loadVideo: (deviceId: string, timestamp: string) => Promise<void>
   resetVideo: () => void
   destroyHls: () => void
@@ -26,7 +27,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
   let hlsInstance: Hls | null = null
   let mediaSessionInitialized = false
-  let seekOffsetSeconds = 0 // Offset to seek to after manifest loads
+  const eventStartOffset = ref(0) // Offset to seek to after manifest loads (in seconds)
 
   // Initialize media session (required for some HLS configurations)
   async function ensureMediaSession(): Promise<boolean> {
@@ -70,8 +71,8 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
     hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
       // Seek to the target timestamp offset if specified
-      if (videoRef.value && seekOffsetSeconds > 0) {
-        videoRef.value.currentTime = seekOffsetSeconds
+      if (videoRef.value && eventStartOffset.value > 0) {
+        videoRef.value.currentTime = eventStartOffset.value
       }
       videoRef.value?.play().catch(() => {
         // Autoplay may be blocked by browser
@@ -155,7 +156,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
 
     // Calculate seek offset from interval start to target timestamp
     const intervalStartMs = new Date(interval.startTimestamp).getTime()
-    seekOffsetSeconds = Math.max(0, (targetTimeMs - intervalStartMs) / 1000)
+    eventStartOffset.value = Math.max(0, (targetTimeMs - intervalStartMs) / 1000)
 
     videoUrl.value = interval.hlsUrl
     loadingVideo.value = false
@@ -170,13 +171,13 @@ export function useHlsPlayer(): HlsPlayerReturn {
     videoUrl.value = null
     videoError.value = null
     loadingVideo.value = false
-    seekOffsetSeconds = 0
+    eventStartOffset.value = 0
   }
 
   // Seek back to the original event timestamp
   function seekToEventStart() {
-    if (videoRef.value && seekOffsetSeconds >= 0) {
-      videoRef.value.currentTime = seekOffsetSeconds
+    if (videoRef.value && eventStartOffset.value >= 0) {
+      videoRef.value.currentTime = eventStartOffset.value
     }
   }
 
@@ -189,6 +190,7 @@ export function useHlsPlayer(): HlsPlayerReturn {
     videoError,
     loadingVideo,
     videoRef,
+    eventStartOffset,
     loadVideo,
     resetVideo,
     destroyHls,


### PR DESCRIPTION
## Summary
- Add event duration display in Camera Information panel (shows time difference between start and end timestamps)
- Show bounding boxes during entire event time range, not just at start
- Track video playback position continuously to show/hide bounding boxes dynamically
- Use 0.25 second tolerance at event boundaries

## Test plan
- [ ] Click on an event with different start/end timestamps
- [ ] Verify duration is displayed in the orange event box
- [ ] Play video and observe bounding boxes appear when playback enters event time range
- [ ] Verify bounding boxes disappear when playback exits event time range
- [ ] Test with both playing and paused video states

🤖 Generated with [Claude Code](https://claude.com/claude-code)