### PR TITLE
Increase page size from 20 to 100 for events and alerts

### DIFF
--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -254,7 +254,7 @@ async function fetchEvents(append = false) {
     type__in: props.selectedTypes,
     startTimestamp__gte: getStartTimestamp(),
     endTimestamp__lte: new Date().toISOString(),
-    pageSize: 20,
+    pageSize: 100,
     pageToken: append ? nextPageToken.value : undefined,
     sort: '-startTimestamp',
     include: [

--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -594,7 +594,7 @@ async function fetchAlerts(append = false) {
     timestamp__gte: getStartTimestamp(),
     timestamp__lte: new Date().toISOString(),
     alertType__in: alertTypes,
-    pageSize: 20,
+    pageSize: 100,
     pageToken: append ? alertsNextPageToken.value : undefined,
     include: ['data', 'actions', 'description'],
     sort: ['-timestamp']


### PR DESCRIPTION
## Summary
- Increase the initial page size for events list from 20 to 100
- Increase the initial page size for alerts list from 20 to 100
- Users will see more items before needing to click "Load more"

## Test plan
- [ ] Verify events list shows up to 100 items before "Load more" appears
- [ ] Verify alerts list shows up to 100 items before "Load more" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)