### PR TITLE
Fix TypeScript error in notifications sort parameter

### DIFF
--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -514,7 +514,7 @@ async function fetchAndMergeNotifications() {
     timestamp__gte: getStartTimestamp(),
     timestamp__lte: new Date().toISOString(),
     pageSize: 100,
-    sort: ['-timestamp']
+    sort: ['-timestamp'] as const
   }
   console.log('[Notifications] Fetching with params:', params)
 


### PR DESCRIPTION
## Summary
- Fix TypeScript build error by adding `as const` to sort parameter in listNotifications call

## Test plan
- [ ] Verify GitHub Actions build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)