### PR TITLE
Add event metadata display and UI improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -110,6 +110,29 @@ function getEventTypeName(type: string): string {
   return type
 }
 
+// Get confidence display text from event data (handles single and multiple values)
+function getEventConfidence(event: Event): string | null {
+  const data = event.data as Array<Record<string, unknown>> | undefined
+  if (!data || !Array.isArray(data)) return null
+
+  // Find all objectClassification entries and extract confidence values
+  const confidences = data
+    .filter(item => item.type === 'een.objectClassification.v1')
+    .map(item => item.confidence as number)
+    .filter(c => typeof c === 'number')
+
+  if (confidences.length === 0) return null
+
+  if (confidences.length === 1) {
+    return `${Math.round(confidences[0] * 100)}%`
+  }
+
+  // Multiple confidence values - show range
+  const min = Math.min(...confidences)
+  const max = Math.max(...confidences)
+  return `${Math.round(min * 100)}%-${Math.round(max * 100)}%`
+}
+
 // Format timestamp for display
 function formatTimestamp(timestamp: string): string {
   const date = new Date(timestamp)
@@ -606,9 +629,9 @@ watch(
         <!-- Event Info -->
         <div class="flex-1 min-w-0">
           <div class="text-xs font-medium truncate" :class="isDark ? 'text-gray-200' : 'text-gray-700'">
-            {{ getEventTypeName(event.type) }}
+            {{ getEventTypeName(event.type) }}<span v-if="getEventConfidence(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> - {{ getEventConfidence(event) }} confidence</span>
           </div>
-          <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-500' : 'text-gray-400'">
+          <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-400' : 'text-gray-400'">
             <span>{{ formatTimestamp(event.startTimestamp) }}</span>
             <span :class="isDark ? 'text-gray-300' : 'text-gray-700'">{{ formatAge(event.startTimestamp) }}</span>
           </div>

--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -257,7 +257,7 @@ function insertEvent(event: Event): void {
 }
 
 // Expose insertEvent for parent component
-defineExpose({ insertEvent })
+defineExpose({ insertEvent, events })
 
 // Fetch historic events
 async function fetchEvents(append = false) {

--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -558,15 +558,22 @@ function getNotificationActions(notification: Notification): string[] {
   return actions
 }
 
-// Get tooltip text for notification action
-function getNotificationActionTooltip(action: string): string {
+// Get tooltip text for notification action (includes description if available)
+function getNotificationActionTooltip(action: string, notification?: Notification): string {
   const tooltips: Record<string, string> = {
     email: 'Email notification',
     sms: 'SMS notification',
     push: 'Push notification',
     gui: 'GUI notification'
   }
-  return tooltips[action] || 'Notification (unknown type)'
+  const baseTooltip = tooltips[action] || 'Notification (unknown type)'
+
+  // Add description on second line if available
+  const description = (notification as unknown as { description?: string })?.description
+  if (description) {
+    return `${baseTooltip}\n${description}`
+  }
+  return baseTooltip
 }
 
 // Fetch event alert condition rules and match to notifications
@@ -954,7 +961,7 @@ defineExpose({
                 :key="action"
                 @click="showNotificationDetails(alert.notification!, $event)"
                 class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
-                :title="getNotificationActionTooltip(action)"
+                :title="getNotificationActionTooltip(action, alert.notification)"
               >
                 <!-- Email icon -->
                 <svg v-if="action === 'email'" class="w-3.5 h-3.5" :class="isDark ? 'text-blue-400' : 'text-blue-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
-import { useAuthStore } from 'een-api-toolkit'
+import { useAuthStore, getEvent } from 'een-api-toolkit'
 import type { Camera, CameraStatus } from 'een-api-toolkit'
 import LivePlayer from '@een/live-video-web-sdk'
 import { useHlsPlayer } from '@/composables/useHlsPlayer'
@@ -16,7 +16,11 @@ const props = defineProps<{
   playbackEventObject?: Record<string, unknown> | null
   isAlertSource?: boolean
   isDark?: boolean
+  eventsList?: Array<{ id: string; creatorId?: string }>
 }>()
+
+// Cache for fetched events (to avoid duplicate API calls)
+const fetchedEventsCache = new Map<string, string>()
 
 // Auth store for baseUrl and token
 const authStore = useAuthStore()
@@ -42,6 +46,9 @@ const isMounted = ref(true)
 // HLS playback state
 const isHlsPlaying = ref(true) // Assume playing initially since autoplay is enabled
 const currentVideoTime = ref(0) // Track current video time for bounding box display
+
+// Triggering event's creatorId (when current event has eventId reference)
+const triggeringEventCreatorId = ref<string | null>(null)
 
 // Calculate event end offset from event object timestamps
 const eventEndOffset = computed(() => {
@@ -180,7 +187,10 @@ const eventDuration = computed(() => {
   const hours = Math.floor(minutes / 60)
   const days = Math.floor(hours / 24)
 
-  if (seconds < 60) {
+  // Show milliseconds if duration is less than 1 second
+  if (diffMs > 0 && diffMs < 1000) {
+    return `${diffMs}ms`
+  } else if (seconds < 60) {
     return `${seconds}s`
   } else if (minutes < 60) {
     const remainingSeconds = seconds % 60
@@ -194,13 +204,8 @@ const eventDuration = computed(() => {
   }
 })
 
-// Format creatorId for display (e.g., "een.defaultCloudAnalytics.v1" -> "default Cloud Analytics")
-const formattedCreatorId = computed(() => {
-  if (!props.playbackEventObject) return null
-
-  const creatorId = props.playbackEventObject.creatorId as string | undefined
-  if (!creatorId) return null
-
+// Helper function to format creatorId (e.g., "een.defaultCloudAnalytics.v1" -> "default Cloud Analytics")
+function formatCreatorId(creatorId: string): string {
   // Strip "een." prefix and version suffix like ".v1", ".v2", etc.
   let formatted = creatorId
     .replace(/^een\./, '')
@@ -210,7 +215,69 @@ const formattedCreatorId = computed(() => {
   formatted = formatted.replace(/([a-z])([A-Z])/g, '$1 $2')
 
   return formatted
+}
+
+// Format creatorId for display, including triggering event source if available
+const formattedCreatorId = computed(() => {
+  if (!props.playbackEventObject) return null
+
+  const creatorId = props.playbackEventObject.creatorId as string | undefined
+  if (!creatorId) return null
+
+  let formattedCurrent = formatCreatorId(creatorId)
+
+  // Show "Event" instead of "events"
+  if (formattedCurrent === 'events') {
+    formattedCurrent = 'Event'
+  }
+
+  // If there's an eventId and we have the triggering event's creatorId, show both
+  const eventId = props.playbackEventObject.eventId as string | undefined
+  if (eventId && triggeringEventCreatorId.value) {
+    return `${formattedCurrent} ← ${triggeringEventCreatorId.value}`
+  }
+
+  return formattedCurrent
 })
+
+// Watch for playbackEventObject changes to fetch triggering event if eventId is present
+watch(() => props.playbackEventObject, async (newEventObject) => {
+  // Reset triggering event creatorId
+  triggeringEventCreatorId.value = null
+
+  if (!newEventObject) return
+
+  const eventId = newEventObject.eventId as string | undefined
+  if (!eventId) return
+
+  // First, check if we already have this event in the cache
+  if (fetchedEventsCache.has(eventId)) {
+    triggeringEventCreatorId.value = fetchedEventsCache.get(eventId) || null
+    return
+  }
+
+  // Second, check if the event is in the provided events list
+  if (props.eventsList) {
+    const existingEvent = props.eventsList.find(e => e.id === eventId)
+    if (existingEvent?.creatorId) {
+      const formattedTriggeringCreatorId = formatCreatorId(existingEvent.creatorId)
+      fetchedEventsCache.set(eventId, formattedTriggeringCreatorId)
+      triggeringEventCreatorId.value = formattedTriggeringCreatorId
+      return
+    }
+  }
+
+  // Finally, fetch from the API
+  const result = await getEvent(eventId)
+  if (!result.error && result.data) {
+    const triggeringCreatorId = result.data.creatorId
+    if (triggeringCreatorId) {
+      const formattedTriggeringCreatorId = formatCreatorId(triggeringCreatorId)
+      fetchedEventsCache.set(eventId, formattedTriggeringCreatorId)
+      triggeringEventCreatorId.value = formattedTriggeringCreatorId
+    }
+  }
+}, { immediate: true })
 
 // Extract confidence from objectClassification data (handles multiple objects)
 const formattedConfidence = computed(() => {

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -212,20 +212,29 @@ const formattedCreatorId = computed(() => {
   return formatted
 })
 
-// Extract confidence from objectClassification data (e.g., 0.71 -> "71%")
+// Extract confidence from objectClassification data (handles multiple objects)
 const formattedConfidence = computed(() => {
   if (!props.playbackEventObject) return null
 
   const data = props.playbackEventObject.data as Array<Record<string, unknown>> | undefined
   if (!data || !Array.isArray(data)) return null
 
-  const classification = data.find(item => item.type === 'een.objectClassification.v1')
-  if (!classification) return null
+  // Find all objectClassification entries and extract confidence values
+  const confidences = data
+    .filter(item => item.type === 'een.objectClassification.v1')
+    .map(item => item.confidence as number)
+    .filter(c => typeof c === 'number')
 
-  const confidence = classification.confidence as number | undefined
-  if (typeof confidence !== 'number') return null
+  if (confidences.length === 0) return null
 
-  return `${Math.round(confidence * 100)}%`
+  if (confidences.length === 1) {
+    return `${Math.round(confidences[0] * 100)}%`
+  }
+
+  // Multiple confidence values - show range
+  const min = Math.min(...confidences)
+  const max = Math.max(...confidences)
+  return `between ${Math.round(min * 100)}% and ${Math.round(max * 100)}%`
 })
 
 // Handle event card click - seek to timestamp and toggle play/pause
@@ -576,7 +585,7 @@ onUnmounted(() => {
 
     <!-- Camera Info Panel -->
     <div
-      class="w-72 flex-shrink-0 rounded-lg p-4 overflow-y-auto border"
+      class="w-80 flex-shrink-0 rounded-lg p-4 overflow-y-auto border"
       :class="isDark ? 'bg-gray-900 border-gray-700' : 'bg-white border-gray-200'"
     >
       <h3 :class="isDark ? 'text-white' : 'text-gray-800'" class="font-semibold text-lg mb-4">Camera Information</h3>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -145,6 +145,9 @@ function handleSseEvent(event: Record<string, unknown>) {
   historicEventsPanelRef.value?.insertEvent(event as unknown as Parameters<typeof historicEventsPanelRef.value.insertEvent>[0])
 }
 
+// Computed events list from HistoricEventsPanel (for MainVideoPlayer to check before API calls)
+const eventsList = computed(() => historicEventsPanelRef.value?.events || [])
+
 onMounted(async () => {
   const result = await getCurrentUser()
 
@@ -200,6 +203,7 @@ onMounted(async () => {
               :playback-event-object="playbackEventObject"
               :is-alert-source="isAlertSource"
               :is-dark="isDark"
+              :events-list="eventsList"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Display event source from `creatorId` in camera info panel (e.g., "default Cloud Analytics")
- Display confidence percentage from event data in camera info panel and event cards
- Handle multiple objects with confidence range (e.g., "45%-47%")
- Add notification description to tooltip (second line)
- Widen Camera Information panel by ~10%
- Lighten timestamp/confidence text in dark mode for better readability

## Test plan
- [ ] Click on an event - verify Source and Confidence display in orange info box
- [ ] Click on event with multiple detected objects - verify confidence shows range
- [ ] Hover over notification icon on alert - verify description shows on second line
- [ ] Verify event cards show confidence inline with event type
- [ ] Check dark mode colors are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)