### PR TITLE
Add workflow to sync develop after production merge

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,47 @@
+name: Sync Develop with Production
+
+# Automatically sync develop branch after PR merges to production
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - production
+
+jobs:
+  sync:
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync develop with production
+        run: |
+          git checkout develop
+          # Pull latest to handle race condition if another PR just merged
+          git pull origin develop --rebase
+          git merge origin/production -m "chore: Sync develop with production after PR #${{ github.event.pull_request.number }}"
+          # Retry push with pull if another workflow pushed first
+          for i in 1 2 3; do
+            if git push origin develop; then
+              echo "Push successful"
+              exit 0
+            fi
+            echo "Push failed, attempt $i/3. Pulling and retrying..."
+            git pull origin develop --rebase
+            sleep 2
+          done
+          echo "Push failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

- Adds GitHub Action workflow that automatically merges production back to develop after a PR is merged to production
- Keeps branches in sync without manual intervention
- Includes retry logic for handling race conditions

## Test plan

- [ ] Merge this PR and verify the sync workflow runs successfully
- [ ] Confirm develop branch receives the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)