### PR TITLE
Release: Comprehensive URL state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This application uses the following functions from [een-api-toolkit](https://git
 - Node.js 18+
 - An Eagle Eye Networks account
 - OAuth client credentials (client ID)
-- An OAuth proxy URL (see [een-api-toolkit documentation](https://www.npmjs.com/package/een-api-toolkit))
+- An OAuth proxy URL (see [een-api-toolkit documentation](https://www.npmjs.com/package/een-api-toolkit) or [een-oauth-proxy](https://github.com/klaushofrichter/een-oauth-proxy) for an implementation)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ The bottom section of the application contains three panels for event management
 
 ## URL Parameters
 
-The application supports deep-linking with URL parameters to restore camera selection, selected camera, and event type filters.
+The application supports deep-linking with URL parameters to restore camera selection, selected camera, event type filters, time range durations, auto-refresh settings, live events toggle, event filter, and dark mode.
 
 ### Full URL Format
 
 ```
-http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>
+http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>&ed=<duration>&ad=<duration>&er=1&ar=1&live=1&filter=1&dark=1
 ```
 
 **Example:**
 ```
-http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj
+http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj&ed=24h&ad=1w&er=1&live=1&dark=1
 ```
 
 ### Parameters
@@ -115,6 +115,13 @@ http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nk
 | `id` | Comma-separated list of visible camera IDs | `id=1005963a,100f030c` |
 | `selected` | Currently selected camera ID (must be in `id` list) | `selected=100f030c` |
 | `events` | Comma-separated event type hashes | `events=nkU,6pF,wOj` |
+| `ed` | Events panel time range duration | `ed=24h` |
+| `ad` | Alerts panel time range duration | `ad=1w` |
+| `er` | Events panel auto-refresh enabled (`1` = on) | `er=1` |
+| `ar` | Alerts panel auto-refresh enabled (`1` = on) | `ar=1` |
+| `live` | Live events SSE feed enabled (`1` = on) | `live=1` |
+| `filter` | Event type filter for alerts enabled (`1` = on) | `filter=1` |
+| `dark` | Dark mode (`1` = on, `0` = off) | `dark=1` |
 
 ### Camera Selection (`id` and `selected`)
 
@@ -141,6 +148,49 @@ Event types are encoded as 3-character hashes to keep URLs short. The hashes use
 | wOj | Device Status |
 
 See [docs/event-type-hashes.md](docs/event-type-hashes.md) for the complete list of all 60 event types and their hashes, including the hash algorithm source code.
+
+### Time Range Duration (`ed` and `ad`)
+
+Controls the time range for the Events and Alerts panels. Valid values:
+
+| Value | Duration |
+|-------|----------|
+| `10m` | Last 10 minutes |
+| `1h` | Last 1 hour (default) |
+| `24h` | Last 24 hours |
+| `1w` | Last week |
+
+Invalid values are ignored and the default (1h) is used. The duration is only included in the URL when not the default value.
+
+### Auto-Refresh (`er` and `ar`)
+
+Controls whether auto-refresh is enabled for the Events and Alerts panels:
+- `er=1` - Enable events auto-refresh
+- `ar=1` - Enable alerts auto-refresh
+
+When enabled, the respective panel refreshes every minute. The parameter is only included in the URL when auto-refresh is enabled.
+
+### Live Events Toggle (`live`)
+
+Controls whether the live events SSE (Server-Sent Events) feed is enabled:
+- `live=1` - Enable live events feed
+
+When enabled, new events are pushed to the Events panel in real-time via SSE. The parameter is only included in the URL when the live feed is enabled.
+
+### Event Filter for Alerts (`filter`)
+
+Controls whether alerts are filtered by the selected event types:
+- `filter=1` - Enable event type filter for alerts
+
+When enabled, only alerts matching the selected event types are shown. The parameter is only included in the URL when the filter is enabled.
+
+### Dark Mode (`dark`)
+
+Controls the application theme:
+- `dark=1` - Enable dark mode
+- `dark=0` - Enable light mode (explicit)
+
+When `dark=1` is in the URL, dark mode is enabled regardless of the user's previous preference. The parameter is only included in the URL when dark mode is enabled.
 
 ### URL Persistence
 

--- a/README.md
+++ b/README.md
@@ -93,25 +93,60 @@ The bottom section of the application contains three panels for event management
 - **Panel Tooltips** - Hover over panel titles to see descriptions
 - **Bounding Box Overlays** - Object detection boxes shown on event thumbnails and video
 
-## URL Camera Selection
+## URL Parameters
 
-You can deep-link directly to specific cameras by adding the `id` parameter to the URL:
+The application supports deep-linking with URL parameters to restore camera selection, selected camera, and event type filters.
+
+### Full URL Format
 
 ```
-http://127.0.0.1:3333?id=1005963a,1003e46b
+http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>
 ```
 
-**Multiple cameras (layout mode):**
-- A **"URL-cameras"** option appears at the top of the layout dropdown
-- Only the specified cameras are displayed in the sidebar
-- If a camera ID is invalid or inaccessible, an error card is shown instead
-- The URL parameters persist through the OAuth login flow
-- Accessing the app without the `id` parameter clears any previously stored camera IDs
+**Example:**
+```
+http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj
+```
 
-**Single camera (auto-sync):**
-- When you select a camera, the URL automatically updates to include its ID
-- Share the URL to let others view the same camera directly
-- The camera auto-selects when loading with a single camera ID in the URL
+### Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `id` | Comma-separated list of visible camera IDs | `id=1005963a,100f030c` |
+| `selected` | Currently selected camera ID (must be in `id` list) | `selected=100f030c` |
+| `events` | Comma-separated event type hashes | `events=nkU,6pF,wOj` |
+
+### Camera Selection (`id` and `selected`)
+
+- **`id` parameter** - Defines which cameras are visible in the sidebar
+  - A **"URL-cameras"** option appears at the top of the layout dropdown
+  - If a camera ID is invalid or inaccessible, an error card is shown
+- **`selected` parameter** - Pre-selects a specific camera from the visible list
+  - Must be one of the IDs in the `id` list (validated on load)
+  - If omitted or invalid, the first camera is selected
+- **Auto-sync** - The URL automatically updates when you change camera selection or visibility
+
+### Event Type Filtering (`events`)
+
+Event types are encoded as 3-character hashes to keep URLs short. The hashes use the DJB2 algorithm with base62 encoding.
+
+**Common event type hashes:**
+
+| Hash | Event Type |
+|------|------------|
+| nkU | Motion Detection |
+| 6pF | Person Detection |
+| X33 | Vehicle Detection |
+| 55Y | Animal Detection |
+| wOj | Device Status |
+
+See [docs/event-type-hashes.md](docs/event-type-hashes.md) for the complete list of all 60 event types and their hashes, including the hash algorithm source code.
+
+### URL Persistence
+
+- All URL parameters persist through the OAuth login flow
+- Parameters are stored in sessionStorage during authentication
+- Sharing a URL allows others to see the exact same view (after login)
 
 ## Technology Stack
 

--- a/docs/event-type-hashes.md
+++ b/docs/event-type-hashes.md
@@ -1,0 +1,106 @@
+# Event Type URL Hashes
+
+This document lists all Eagle Eye Networks event types and their corresponding 3-character URL hashes used in the `events` query parameter.
+
+## Hash Algorithm
+
+The hash is generated using the DJB2 algorithm, converted to base62 encoding (0-9, a-z, A-Z) for URL-safe representation:
+
+```typescript
+const CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+/**
+ * Generate a 3-character hash from an event type string.
+ * Uses DJB2 hash algorithm converted to base62.
+ */
+export function hashEventType(eventType: string): string {
+  let hash = 5381
+  for (let i = 0; i < eventType.length; i++) {
+    hash = ((hash << 5) + hash + eventType.charCodeAt(i)) >>> 0
+  }
+  let result = ''
+  for (let i = 0; i < 3; i++) {
+    result += CHARS[hash % 62]
+    hash = Math.floor(hash / 62)
+  }
+  return result
+}
+```
+
+## Event Type Hash Table
+
+| Hash | Event Name | Event Type |
+|------|------------|------------|
+| sMI | Account Creation | een.accountCreationEvent.v1 |
+| xDo | Account Deletion | een.accountDeletionEvent.v1 |
+| KYp | Account Update | een.accountUpdateEvent.v1 |
+| 55Y | Animal Detection | een.animalDetectionEvent.v1 |
+| 0gG | Battery Level Update | een.batteryLevelUpdateEvent.v1 |
+| zik | Crowd Formation Detection | een.crowdFormationDetectionEvent.v1 |
+| 3Cc | Device Creation | een.deviceCreationEvent.v1 |
+| cF7 | Device Deletion | een.deviceDeletionEvent.v1 |
+| yIm | Device I/O | een.deviceIOEvent.v1 |
+| 1pF | Device Operation | een.deviceOperationEvent.v1 |
+| wOj | Device Status | een.deviceCloudStatusUpdateEvent.v1 |
+| 5Kd | Device Update | een.deviceUpdateEvent.v1 |
+| GAy | Door Status | een.doorStatusEvent.v1 |
+| ztu | EEVA Event | een.eevaQueryEvent.v1 |
+| CoN | Evacuate Protocol | een.evacuateProtocolEvent.v1 |
+| qHj | Face Detection | een.faceDetectionEvent.v1 |
+| SNz | Fall Detection Event | een.fallDetectionEvent.v1 |
+| VZJ | Fight Detection Event | een.fightDetectionEvent.v1 |
+| t7I | Fire Detection | een.fireDetectionEvent.v1 |
+| qM1 | Fleet Code Recognition | een.fleetCodeRecognitionEvent.v1 |
+| NbY | Gun Detection | een.gunDetectionEvent.v1 |
+| NHc | Gunshot Audio Detection | een.gunShotAudioDetectionEvent.v1 |
+| YS9 | Hands Up Detection Event | een.handsUpDetectionEvent.v1 |
+| 9BR | Hold Protocol | een.holdProtocolEvent.v1 |
+| ek9 | Job Creation | een.jobCreationEvent.v1 |
+| jbP | Job Deletion | een.jobDeletionEvent.v1 |
+| kMt | Job Update | een.jobUpdateEvent.v1 |
+| 7b9 | Layout Creation | een.layoutCreationEvent.v1 |
+| c2P | Layout Deletion | een.layoutDeletionEvent.v1 |
+| plX | Layout Update | een.layoutUpdateEvent.v1 |
+| Erm | License Plate Recognition | een.lprPlateReadEvent.v1 |
+| zTs | Lockdown Protocol | een.lockdownProtocolEvent.v1 |
+| wW9 | Loiter Detection | een.loiterDetectionEvent.v1 |
+| pOx | Measurement Threshold Status | een.measurementThresholdStatusEvent.v1 |
+| nkU | Motion Detection | een.motionDetectionEvent.v1 |
+| AJa | Motion in Region Detection | een.motionInRegionDetectionEvent.v1 |
+| 4CD | Object Intrusion | een.objectIntrusionEvent.v1 |
+| 1Jn | Object Line Cross | een.objectLineCrossEvent.v1 |
+| y1L | Object Line Cross Count | een.objectLineCrossCountEvent.v1 |
+| plc | Object Removal | een.objectRemovalEvent.v1 |
+| bnl | Panic Button | een.panicButtonEvent.v1 |
+| 6pF | Person Detection | een.personDetectionEvent.v1 |
+| Akk | Person Tailgate Event | een.personTailgateEvent.v1 |
+| y4g | POS Transaction | een.posTransactionEvent.v1 |
+| itL | PPE Violation | een.ppeViolationEvent.v1 |
+| yRM | Ptz Position Update | een.ptzPositionUpdateEvent.v1 |
+| SzG | Scene Label | een.sceneLabelEvent.v1 |
+| N11 | Secure Protocol | een.secureProtocolEvent.v1 |
+| HUI | Shelter Protocol | een.shelterProtocolEvent.v1 |
+| xYB | Spill Detection | een.spillDetectionEvent.v1 |
+| 5PI | T3 Alarm Audio Detection | een.t3AlarmAudioDetectionEvent.v1 |
+| 632 | T4 Alarm Audio Detection | een.t4AlarmAudioDetectionEvent.v1 |
+| yuv | Tamper Detection | een.tamperDetectionEvent.v1 |
+| jNo | Thermal Camera Threshold Crossed | een.thermalCameraThresholdStatusEvent.v1 |
+| OeS | User Creation | een.userCreationEvent.v1 |
+| XhN | User Deletion | een.userDeletionEvent.v1 |
+| Cjx | User Update | een.userUpdateEvent.v1 |
+| b99 | Vape Detection | een.vapeDetectionEvent.v1 |
+| X33 | Vehicle Detection | een.vehicleDetectionEvent.v1 |
+| Ars | Violence Detection | een.violenceDetectionEvent.v1 |
+
+## Usage Example
+
+To filter for Motion Detection and Person Detection events:
+
+```
+?events=nkU,6pF
+```
+
+Full URL example:
+```
+http://127.0.0.1:3333/?id=1005963a,100f030c&selected=100f030c&events=nkU,6pF
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ const user = ref<UserProfile | null>(null)
 const route = useRoute()
 
 // Dark mode
-const { isDark, toggle: toggleDarkMode } = useDarkMode()
+const { isDark, toggle: toggleDarkMode, setDark } = useDarkMode()
 
 // Video export state
 const { status: exportStatus, progressPercent: exportProgress, isActive: exportIsActive } = useVideoExport()
@@ -121,6 +121,14 @@ onMounted(() => {
   // This restores the session if a valid token exists
   authStore.initialize()
   loadUser()
+
+  // Check for dark mode URL parameter (overrides localStorage)
+  const urlDark = sessionStorage.getItem('een_url_dark')
+  if (urlDark === '1') {
+    setDark(true)
+  } else if (urlDark === '0') {
+    setDark(false)
+  }
 })
 
 onUnmounted(() => {

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -9,6 +9,7 @@ import ErrorCameraCard from './ErrorCameraCard.vue'
 const props = defineProps<{
   selectedCameraId: string | null
   initialCameraId?: string | null
+  initialSelectedCameraId?: string | null
   isLivePlayback?: boolean
 }>()
 
@@ -202,9 +203,9 @@ function applyLayoutFilter() {
   // Current camera not in list or not visible on first page - select camera
   currentPage.value = 1
   if (cameras.value.length > 0) {
-    // Check if initialCameraId is provided and exists in the list
-    if (props.initialCameraId) {
-      const initialCamera = cameras.value.find(cam => cam.id === props.initialCameraId)
+    // Check if initialSelectedCameraId is provided and exists in the list
+    if (props.initialSelectedCameraId) {
+      const initialCamera = cameras.value.find(cam => cam.id === props.initialSelectedCameraId)
       if (initialCamera) {
         // Find which page the initial camera is on and navigate there
         const cameraIndex = cameras.value.indexOf(initialCamera)

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -270,8 +270,9 @@ onMounted(async () => {
   // Check for URL camera IDs in sessionStorage
   const storedCameraIds = sessionStorage.getItem('een_url_camera_ids')
   if (storedCameraIds) {
-    // Parse comma-separated camera IDs
-    urlCameraIds.value = storedCameraIds.split(',').map(id => id.trim()).filter(id => id.length > 0)
+    // Parse comma-separated camera IDs and remove duplicates
+    const parsedIds = storedCameraIds.split(',').map(id => id.trim()).filter(id => id.length > 0)
+    urlCameraIds.value = [...new Set(parsedIds)]
     // Auto-select "URL-cameras" if we have URL camera IDs
     if (urlCameraIds.value.length > 0) {
       selectedLayoutId.value = 'url'

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -17,6 +17,7 @@ const isDark = inject<Ref<boolean>>('isDark', ref(false))
 
 const emit = defineEmits<{
   'select-camera': [camera: Camera]
+  'visible-cameras-changed': [cameraIds: string[]]
 }>()
 
 // Camera data state
@@ -175,6 +176,9 @@ function applyLayoutFilter() {
 
   // Total size includes accessible cameras + inaccessible error cards
   totalSize.value = cameras.value.length + inaccessibleCameraIds.value.length
+
+  // Emit visible camera IDs for URL sync
+  emit('visible-cameras-changed', cameras.value.map(cam => cam.id))
 
   // Check if current camera is in the filtered list
   const currentCameraId = props.selectedCameraId

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -178,9 +178,6 @@ function applyLayoutFilter() {
   // Total size includes accessible cameras + inaccessible error cards
   totalSize.value = cameras.value.length + inaccessibleCameraIds.value.length
 
-  // Emit visible camera IDs for URL sync
-  emit('visible-cameras-changed', cameras.value.map(cam => cam.id))
-
   // Check if current camera is in the filtered list
   const currentCameraId = props.selectedCameraId
   const currentCameraIndex = currentCameraId
@@ -195,7 +192,7 @@ function applyLayoutFilter() {
     if (isVisibleOnFirstPage) {
       // Keep current camera selected, reset to first page
       currentPage.value = 1
-      // Don't emit - keep existing selection
+      emitVisibleCameras()
       return
     }
   }
@@ -211,12 +208,14 @@ function applyLayoutFilter() {
         const cameraIndex = cameras.value.indexOf(initialCamera)
         currentPage.value = Math.floor(cameraIndex / camerasPerPage.value) + 1
         emit('select-camera', initialCamera)
+        emitVisibleCameras()
         return
       }
     }
     // Fall back to first camera
     emit('select-camera', cameras.value[0])
   }
+  emitVisibleCameras()
 }
 
 // Handle layout selection change
@@ -226,16 +225,30 @@ function handleLayoutChange(event: Event) {
   applyLayoutFilter()
 }
 
+// Get camera IDs visible on current page
+function getVisibleCameraIds(): string[] {
+  const start = (currentPage.value - 1) * camerasPerPage.value
+  const end = start + camerasPerPage.value
+  return cameras.value.slice(start, end).map(cam => cam.id)
+}
+
+// Emit visible camera IDs for URL sync
+function emitVisibleCameras() {
+  emit('visible-cameras-changed', getVisibleCameraIds())
+}
+
 // Pagination navigation
 function nextPage() {
   if (hasNextPage.value) {
     currentPage.value++
+    emitVisibleCameras()
   }
 }
 
 function prevPage() {
   if (hasPrevPage.value) {
     currentPage.value--
+    emitVisibleCameras()
   }
 }
 
@@ -260,6 +273,9 @@ function handleResize() {
     // Recalculate current page to keep roughly same cameras visible
     const newPage = Math.floor(currentFirstCameraIndex / newCardsPerPage) + 1
     currentPage.value = Math.max(1, Math.min(newPage, totalPages.value))
+
+    // Emit updated visible cameras after resize
+    emitVisibleCameras()
   }
 }
 

--- a/src/components/EventTypesPanel.vue
+++ b/src/components/EventTypesPanel.vue
@@ -19,6 +19,9 @@ const availableEventTypes = ref<string[]>([])
 const selectedEventTypes = ref<string[]>([])
 const eventTypeNames = ref<Map<string, string>>(new Map())
 
+// Track if this is the first camera selection (for default selection behavior)
+const isFirstCameraSelection = ref(true)
+
 // Motion detection event type constant
 const MOTION_DETECTION_EVENT = 'een.motionDetectionEvent.v1'
 
@@ -77,6 +80,9 @@ async function fetchAvailableEventTypes() {
     return
   }
 
+  // Remember previously selected event types before fetching new ones
+  const previouslySelectedTypes = [...selectedEventTypes.value]
+
   loading.value = true
   error.value = null
 
@@ -92,14 +98,22 @@ async function fetchAvailableEventTypes() {
   } else {
     availableEventTypes.value = result.data.type || []
 
-    // Preselect motion detection if available, otherwise select all
-    if (availableEventTypes.value.includes(MOTION_DETECTION_EVENT)) {
-      selectedEventTypes.value = [MOTION_DETECTION_EVENT]
-    } else if (availableEventTypes.value.length > 0) {
-      // If no motion detection, select the first available type
-      selectedEventTypes.value = [availableEventTypes.value[0]]
+    if (isFirstCameraSelection.value) {
+      // First camera: preselect motion detection if available, otherwise first type
+      isFirstCameraSelection.value = false
+      if (availableEventTypes.value.includes(MOTION_DETECTION_EVENT)) {
+        selectedEventTypes.value = [MOTION_DETECTION_EVENT]
+      } else if (availableEventTypes.value.length > 0) {
+        selectedEventTypes.value = [availableEventTypes.value[0]]
+      } else {
+        selectedEventTypes.value = []
+      }
     } else {
-      selectedEventTypes.value = []
+      // Subsequent cameras: keep only previously selected types that are available
+      const intersection = previouslySelectedTypes.filter(type =>
+        availableEventTypes.value.includes(type)
+      )
+      selectedEventTypes.value = intersection
     }
 
     emit('update:selectedTypes', selectedEventTypes.value)

--- a/src/components/EventTypesPanel.vue
+++ b/src/components/EventTypesPanel.vue
@@ -2,10 +2,12 @@
 import { ref, watch, computed, onMounted } from 'vue'
 import { listEventFieldValues, listEventTypes } from 'een-api-toolkit'
 import type { Camera, EenError } from 'een-api-toolkit'
+import { buildHashLookup, hashStringToEventTypes } from '@/utils/eventTypeHash'
 
 const props = defineProps<{
   camera: Camera | null
   isDark?: boolean
+  initialEventHashes?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -99,9 +101,23 @@ async function fetchAvailableEventTypes() {
     availableEventTypes.value = result.data.type || []
 
     if (isFirstCameraSelection.value) {
-      // First camera: preselect motion detection if available, otherwise first type
+      // First camera: try URL hashes first, then default behavior
       isFirstCameraSelection.value = false
-      if (availableEventTypes.value.includes(MOTION_DETECTION_EVENT)) {
+
+      if (props.initialEventHashes) {
+        // Restore from URL: decode hashes and filter to available types
+        const hashLookup = buildHashLookup(availableEventTypes.value)
+        const restoredTypes = hashStringToEventTypes(props.initialEventHashes, hashLookup)
+        if (restoredTypes.length > 0) {
+          selectedEventTypes.value = restoredTypes
+        } else if (availableEventTypes.value.includes(MOTION_DETECTION_EVENT)) {
+          selectedEventTypes.value = [MOTION_DETECTION_EVENT]
+        } else if (availableEventTypes.value.length > 0) {
+          selectedEventTypes.value = [availableEventTypes.value[0]]
+        } else {
+          selectedEventTypes.value = []
+        }
+      } else if (availableEventTypes.value.includes(MOTION_DETECTION_EVENT)) {
         selectedEventTypes.value = [MOTION_DETECTION_EVENT]
       } else if (availableEventTypes.value.length > 0) {
         selectedEventTypes.value = [availableEventTypes.value[0]]

--- a/src/components/HistoricEventsPanel.vue
+++ b/src/components/HistoricEventsPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed, nextTick, onUnmounted } from 'vue'
+import { ref, watch, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { listEvents, listEventTypes } from 'een-api-toolkit'
 import type { Camera, Event, EenError } from 'een-api-toolkit'
 import { useImageCache } from '@/composables/useImageCache'
@@ -12,6 +12,8 @@ const props = defineProps<{
   selectedTypes: string[]
   isDark?: boolean
   activeEventId?: string | null
+  initialDuration?: number | null
+  initialAutoRefresh?: boolean
   liveFeedButtonLabel?: string
   liveFeedButtonClass?: string
   liveFeedCanToggle?: boolean
@@ -20,6 +22,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'event-clicked', event: { cameraId: string; timestamp: string; eventType: string; eventId: string; boundingBoxes: BoundingBox[]; eventObject: Record<string, unknown> }): void
   (e: 'toggle-live-feed'): void
+  (e: 'duration-changed', duration: number): void
+  (e: 'auto-refresh-changed', enabled: boolean): void
 }>()
 
 // Use shared image cache
@@ -43,8 +47,8 @@ const isAtTop = ref(true)
 const boundingBoxesMap = ref<Map<string, BoundingBox[]>>(new Map())
 const sseInsertedIds = ref<Set<string>>(new Set()) // Track events inserted via SSE (shown with blue background)
 
-// Auto-refresh state
-const autoRefresh = ref(false)
+// Auto-refresh state (initialize from prop)
+const autoRefresh = ref(props.initialAutoRefresh ?? false)
 const refreshCountdown = ref(0) // seconds until next refresh
 const AUTO_REFRESH_INTERVAL = 60 // 1 minute in seconds
 let refreshTimer: ReturnType<typeof setInterval> | null = null
@@ -59,7 +63,16 @@ const timeRangeOptions = [
   { label: 'Last 24h', value: 60 * 24 },
   { label: 'Last week', value: 60 * 24 * 7 }
 ]
-const selectedTimeRange = ref(60) // Default: 1 hour
+// Valid duration values for validation
+const validDurations = new Set([10, 60, 1440, 10080])
+// Initialize from prop if valid, otherwise default to 1 hour
+const getInitialDuration = () => {
+  if (props.initialDuration && validDurations.has(props.initialDuration)) {
+    return props.initialDuration
+  }
+  return 60
+}
+const selectedTimeRange = ref(getInitialDuration())
 
 // Computed
 const hasMoreEvents = computed(() => !!nextPageToken.value)
@@ -499,6 +512,14 @@ watch(autoRefresh, (enabled) => {
   } else {
     stopRefreshTimer()
   }
+  emit('auto-refresh-changed', enabled)
+})
+
+// Start auto-refresh timer on mount if enabled
+onMounted(() => {
+  if (autoRefresh.value) {
+    startRefreshTimer()
+  }
 })
 
 // Cleanup on unmount
@@ -529,11 +550,12 @@ watch(
   { immediate: true, deep: true }
 )
 
-// Watch for time range changes - just fetch new events
+// Watch for time range changes - just fetch new events and emit change
 watch(
   selectedTimeRange,
-  () => {
+  (newValue) => {
     fetchEvents()
+    emit('duration-changed', newValue)
   }
 )
 </script>

--- a/src/components/LiveEventsPanel.vue
+++ b/src/components/LiveEventsPanel.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
-import { ref, watch, computed, onUnmounted } from 'vue'
+import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import {
   createEventSubscription,
   connectToEventSubscription,
   deleteEventSubscription,
   listAlerts,
   listNotifications,
-  listEventAlertConditionRules
+  listEventAlertConditionRules,
+  listAlertActions
 } from 'een-api-toolkit'
-import type { Camera, EenError, SSEEvent, SSEConnection, SSEConnectionStatus, Alert, Notification, EventAlertConditionRule } from 'een-api-toolkit'
+import type { Camera, EenError, SSEEvent, SSEConnection, SSEConnectionStatus, Alert, Notification, EventAlertConditionRule, AutomationAlertAction } from 'een-api-toolkit'
 
 // Extended alert type with optional notification and rule data
 interface AlertWithNotification extends Alert {
-  notification?: Notification
+  notifications?: Notification[]
   eventAlertConditionRule?: EventAlertConditionRule
 }
 import { useImageCache } from '@/composables/useImageCache'
@@ -23,11 +24,19 @@ const props = defineProps<{
   selectedTypes: string[]
   isDark?: boolean
   activeAlertId?: string | null
+  initialDuration?: number | null
+  initialAutoRefresh?: boolean
+  initialLiveFeed?: boolean
+  initialEventFilter?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'sse-event', event: Record<string, unknown>): void
   (e: 'alert-clicked', alert: { alertId: string; alertObject: Record<string, unknown> }): void
+  (e: 'duration-changed', duration: number): void
+  (e: 'auto-refresh-changed', enabled: boolean): void
+  (e: 'live-feed-changed', enabled: boolean): void
+  (e: 'event-filter-changed', enabled: boolean): void
 }>()
 
 // Use shared image cache
@@ -41,7 +50,7 @@ const subscriptionId = ref<string | null>(null)
 const sseConnection = ref<SSEConnection | null>(null)
 const connectionStatus = ref<SSEConnectionStatus>('disconnected')
 const connectionError = ref<EenError | null>(null)
-const liveFeedEnabled = ref(false) // User's desired state - always reconnect when enabled
+const liveFeedEnabled = ref(props.initialLiveFeed ?? false) // User's desired state - always reconnect when enabled
 
 // Alerts State
 const alerts = ref<AlertWithNotification[]>([])
@@ -63,14 +72,23 @@ const showRuleModal = ref(false)
 const selectedRule = ref<EventAlertConditionRule | null>(null)
 const ruleCopied = ref(false)
 
+// Action modal state
+const showActionModal = ref(false)
+const selectedAction = ref<AutomationAlertAction | null>(null)
+const selectedActionExecution = ref<Record<string, unknown> | null>(null) // Execution data from alert
+const actionCopied = ref(false)
+
 // Store for all event alert condition rules
 const eventAlertConditionRules = ref<Map<string, EventAlertConditionRule>>(new Map())
 
-// Event type filter state for alerts
-const eventFilterEnabled = ref(false)
+// Store for all alert actions (definitions)
+const alertActionsMap = ref<Map<string, AutomationAlertAction>>(new Map())
 
-// Auto-refresh state for alerts
-const autoRefresh = ref(false)
+// Event type filter state for alerts (initialize from prop)
+const eventFilterEnabled = ref(props.initialEventFilter ?? false)
+
+// Auto-refresh state for alerts (initialize from prop)
+const autoRefresh = ref(props.initialAutoRefresh ?? false)
 const refreshCountdown = ref(0) // seconds until next refresh
 const AUTO_REFRESH_INTERVAL = 60 // 1 minute in seconds
 let refreshTimer: ReturnType<typeof setInterval> | null = null
@@ -82,7 +100,16 @@ const timeRangeOptions = [
   { label: 'Last 24h', value: 60 * 24 },
   { label: 'Last week', value: 60 * 24 * 7 }
 ]
-const selectedTimeRange = ref(60) // Default: 1 hour
+// Valid duration values for validation
+const validDurations = new Set([10, 60, 1440, 10080])
+// Initialize from prop if valid, otherwise default to 1 hour
+const getInitialDuration = () => {
+  if (props.initialDuration && validDurations.has(props.initialDuration)) {
+    return props.initialDuration
+  }
+  return 60
+}
+const selectedTimeRange = ref(getInitialDuration())
 
 // Reconnection timer (SSE subscriptions expire after 15 minutes)
 const SUBSCRIPTION_TTL_MS = 14 * 60 * 1000 // Reconnect at 14 minutes (before 15 min expiry)
@@ -154,10 +181,12 @@ function toggleLiveFeed() {
   if (isConnected.value || isConnecting.value) {
     // Turn off - disconnect and disable
     liveFeedEnabled.value = false
+    emit('live-feed-changed', false)
     disconnect()
   } else {
     // Turn on - enable and connect
     liveFeedEnabled.value = true
+    emit('live-feed-changed', true)
     if (canConnect.value) {
       connect()
     }
@@ -167,6 +196,7 @@ function toggleLiveFeed() {
 // Toggle event type filter for alerts
 function toggleEventFilter() {
   eventFilterEnabled.value = !eventFilterEnabled.value
+  emit('event-filter-changed', eventFilterEnabled.value)
   // Refresh alerts with new filter setting
   fetchAlerts()
 }
@@ -468,11 +498,13 @@ function getAlertTypeName(type: string): string {
   return type
 }
 
-// Handle alert click - emit alert data for display
-function handleAlertClick(alert: Alert) {
+// Handle alert click - emit alert data for display (exclude notifications as they're accessible via icons)
+function handleAlertClick(alert: AlertWithNotification) {
+  // Create a copy without the notifications property (they're accessible via their own icons)
+  const { notifications, eventAlertConditionRule, ...alertData } = alert
   emit('alert-clicked', {
     alertId: alert.id,
-    alertObject: alert as unknown as Record<string, unknown>
+    alertObject: alertData as unknown as Record<string, unknown>
   })
 }
 
@@ -523,22 +555,21 @@ async function fetchAndMergeNotifications() {
     return
   }
 
-  // Create a map of alertId -> notification
-  const notificationsByAlertId = new Map<string, Notification>()
+  // Create a map of alertId -> notifications array (can have multiple per alert)
+  const notificationsByAlertId = new Map<string, Notification[]>()
   for (const notification of result.data.results) {
     if (notification.alertId) {
-      // Only keep the first (most recent) notification per alert
-      if (!notificationsByAlertId.has(notification.alertId)) {
-        notificationsByAlertId.set(notification.alertId, notification)
-      }
+      const existing = notificationsByAlertId.get(notification.alertId) || []
+      existing.push(notification)
+      notificationsByAlertId.set(notification.alertId, existing)
     }
   }
 
   // Merge notifications into alerts
   for (const alert of alerts.value) {
-    const notification = notificationsByAlertId.get(alert.id)
-    if (notification) {
-      alert.notification = notification
+    const notifications = notificationsByAlertId.get(alert.id)
+    if (notifications && notifications.length > 0) {
+      alert.notifications = notifications
     }
   }
 }
@@ -547,6 +578,11 @@ async function fetchAndMergeNotifications() {
 function getServiceRuleIdFromNotification(notification: Notification): string | undefined {
   // serviceRuleId exists in the API response but may not be typed
   return (notification as unknown as { serviceRuleId?: string }).serviceRuleId
+}
+
+// Helper to get serviceRuleId directly from alert (may not be typed)
+function getServiceRuleIdFromAlert(alert: Alert): string | undefined {
+  return (alert as unknown as { serviceRuleId?: string }).serviceRuleId
 }
 
 // Get notification actions for display (returns array of action types)
@@ -576,23 +612,46 @@ function getNotificationActionTooltip(action: string, notification?: Notificatio
   return baseTooltip
 }
 
-// Fetch event alert condition rules and match to notifications
-async function fetchAndMatchEventAlertConditionRules() {
-  // Check if any alerts have notifications with serviceRuleId
-  const alertsWithNotificationRuleId = alerts.value.filter(alert => {
-    if (!alert.notification) return false
-    return getServiceRuleIdFromNotification(alert.notification)
-  })
-  if (alertsWithNotificationRuleId.length === 0) return
+// Get actions from alert (e.g., zapier, webhook) - actions is an object with UUIDs as keys
+// Returns array with id (the key) and execution data
+function getAlertActions(alert: AlertWithNotification): Array<{ id: string; type: string; name?: string; execution: Record<string, unknown> }> {
+  // Actions can be on the alert itself (from the raw alert data)
+  const alertData = alert as unknown as { actions?: Record<string, { type: string; name?: string }> }
+  const actions = alertData.actions
 
-  // Get unique serviceRuleIds that we need to fetch
+  if (!actions || typeof actions !== 'object') return []
+
+  // Convert object entries to array with id included
+  return Object.entries(actions).map(([id, execution]) => ({
+    id,
+    type: execution.type,
+    name: execution.name,
+    execution: execution as Record<string, unknown>
+  }))
+}
+
+// Fetch event alert condition rules and match to alerts
+async function fetchAndMatchEventAlertConditionRules() {
+  // Get unique serviceRuleIds from alerts (directly or from notifications)
   const uniqueRuleIds = new Set<string>()
-  for (const alert of alertsWithNotificationRuleId) {
-    const ruleId = getServiceRuleIdFromNotification(alert.notification!)
-    if (ruleId) {
-      uniqueRuleIds.add(ruleId)
+  for (const alert of alerts.value) {
+    // Check alert's own serviceRuleId
+    const alertRuleId = getServiceRuleIdFromAlert(alert)
+    if (alertRuleId) {
+      uniqueRuleIds.add(alertRuleId)
+    }
+    // Also check notifications' serviceRuleIds
+    if (alert.notifications) {
+      for (const notification of alert.notifications) {
+        const notificationRuleId = getServiceRuleIdFromNotification(notification)
+        if (notificationRuleId) {
+          uniqueRuleIds.add(notificationRuleId)
+        }
+      }
     }
   }
+
+  if (uniqueRuleIds.size === 0) return
 
   // Only fetch rules we don't already have
   const ruleIdsToFetch = Array.from(uniqueRuleIds).filter(id => !eventAlertConditionRules.value.has(id))
@@ -611,18 +670,58 @@ async function fetchAndMatchEventAlertConditionRules() {
     }
   }
 
-  // Match rules to alerts that have notifications with serviceRuleId
+  // Match rules to alerts (check alert's serviceRuleId first, then notifications')
   for (const alert of alerts.value) {
-    if (alert.notification) {
-      const ruleId = getServiceRuleIdFromNotification(alert.notification)
-      if (ruleId) {
-        const rule = eventAlertConditionRules.value.get(ruleId)
-        if (rule) {
-          alert.eventAlertConditionRule = rule
+    // Try alert's own serviceRuleId first
+    const alertRuleId = getServiceRuleIdFromAlert(alert)
+    if (alertRuleId) {
+      const rule = eventAlertConditionRules.value.get(alertRuleId)
+      if (rule) {
+        alert.eventAlertConditionRule = rule
+        continue
+      }
+    }
+    // Fall back to notifications' serviceRuleId
+    if (alert.notifications) {
+      for (const notification of alert.notifications) {
+        const notificationRuleId = getServiceRuleIdFromNotification(notification)
+        if (notificationRuleId) {
+          const rule = eventAlertConditionRules.value.get(notificationRuleId)
+          if (rule) {
+            alert.eventAlertConditionRule = rule
+            break
+          }
         }
       }
     }
   }
+}
+
+// Fetch all alert actions (definitions) and store in map
+async function fetchAlertActions() {
+  // Only fetch if we don't have any yet
+  if (alertActionsMap.value.size > 0) return
+
+  let pageToken: string | undefined = undefined
+
+  do {
+    const result = await listAlertActions({
+      pageSize: 100,
+      ...(pageToken ? { pageToken } : {})
+    })
+
+    if (result.error) {
+      // Silently fail - alert actions are supplementary
+      return
+    }
+
+    // Add each action to the Map by its id
+    for (const action of result.data.results) {
+      alertActionsMap.value.set(action.id, action)
+    }
+
+    pageToken = result.data.nextPageToken
+  } while (pageToken)
 }
 
 // Show notification modal
@@ -637,6 +736,31 @@ function showRuleDetails(rule: EventAlertConditionRule, event: MouseEvent) {
   event.stopPropagation() // Prevent alert click
   selectedRule.value = rule
   showRuleModal.value = true
+}
+
+// Show action modal - looks up action definition by ID
+function showActionDetails(actionId: string, execution: Record<string, unknown>, event: MouseEvent) {
+  event.stopPropagation() // Prevent alert click
+
+  // Look up the action definition
+  const actionDefinition = alertActionsMap.value.get(actionId)
+  selectedAction.value = actionDefinition || null
+  selectedActionExecution.value = execution
+  showActionModal.value = true
+}
+
+// Copy action data to clipboard
+async function copyActionToClipboard() {
+  if (!selectedAction.value) return
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(selectedAction.value, null, 2))
+    actionCopied.value = true
+    setTimeout(() => {
+      actionCopied.value = false
+    }, 2000)
+  } catch {
+    // Clipboard access denied or not supported
+  }
 }
 
 // Copy rule data to clipboard
@@ -672,6 +796,7 @@ function handleModalEscKey(event: KeyboardEvent) {
   if (event.key === 'Escape') {
     showNotificationModal.value = false
     showRuleModal.value = false
+    showActionModal.value = false
   }
 }
 
@@ -692,6 +817,17 @@ watch(showRuleModal, (isOpen) => {
   } else {
     document.removeEventListener('keydown', handleModalEscKey)
     selectedRule.value = null
+  }
+})
+
+// Watch action modal state to add/remove ESC key listener
+watch(showActionModal, (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('keydown', handleModalEscKey)
+  } else {
+    document.removeEventListener('keydown', handleModalEscKey)
+    selectedAction.value = null
+    selectedActionExecution.value = null
   }
 })
 
@@ -747,6 +883,9 @@ async function fetchAlerts(append = false) {
 
     // Fetch event alert condition rules and match to notifications
     await fetchAndMatchEventAlertConditionRules()
+
+    // Fetch alert action definitions
+    await fetchAlertActions()
   }
 
   alertsLoading.value = false
@@ -789,6 +928,7 @@ watch(autoRefresh, (enabled) => {
   } else {
     stopRefreshTimer()
   }
+  emit('auto-refresh-changed', enabled)
 })
 
 // Watch for camera changes - fetch alerts
@@ -800,11 +940,12 @@ watch(
   }
 )
 
-// Watch for time range changes - fetch new alerts
+// Watch for time range changes - fetch new alerts and emit change
 watch(
   selectedTimeRange,
-  () => {
+  (newValue) => {
     fetchAlerts()
+    emit('duration-changed', newValue)
   }
 )
 
@@ -812,6 +953,17 @@ watch(
 if (props.camera) {
   fetchAlerts()
 }
+
+// Start auto-refresh timer and live feed on mount if enabled
+onMounted(() => {
+  if (autoRefresh.value) {
+    startRefreshTimer()
+  }
+  // Start live feed connection if enabled and we have camera and types
+  if (liveFeedEnabled.value && props.camera && props.selectedTypes.length > 0) {
+    connect()
+  }
+})
 
 // Cleanup on unmount
 onUnmounted(async () => {
@@ -954,40 +1106,7 @@ defineExpose({
             <span class="text-xs font-medium truncate" :class="isDark ? 'text-gray-200' : 'text-gray-700'">
               {{ alert.alertName || getAlertTypeName(alert.alertType) }}
             </span>
-            <!-- Notification Icons (if notification exists for this alert) -->
-            <template v-if="alert.notification">
-              <button
-                v-for="action in getNotificationActions(alert.notification)"
-                :key="action"
-                @click="showNotificationDetails(alert.notification!, $event)"
-                class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
-                :title="getNotificationActionTooltip(action, alert.notification)"
-              >
-                <!-- Email icon -->
-                <svg v-if="action === 'email'" class="w-3.5 h-3.5" :class="isDark ? 'text-blue-400' : 'text-blue-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-                <!-- SMS icon (chat bubble) -->
-                <svg v-else-if="action === 'sms'" class="w-3.5 h-3.5" :class="isDark ? 'text-green-400' : 'text-green-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                </svg>
-                <!-- Push notification icon (bell) -->
-                <svg v-else-if="action === 'push'" class="w-3.5 h-3.5" :class="isDark ? 'text-yellow-400' : 'text-yellow-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-                </svg>
-                <!-- GUI icon (desktop/monitor) -->
-                <svg v-else-if="action === 'gui'" class="w-3.5 h-3.5" :class="isDark ? 'text-cyan-400' : 'text-cyan-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-                <!-- Unknown/default icon (drum) -->
-                <svg v-else class="w-3.5 h-3.5" :class="isDark ? 'text-gray-400' : 'text-gray-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <ellipse cx="12" cy="8" rx="8" ry="4" stroke-width="2" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8v8c0 2.21 3.58 4 8 4s8-1.79 8-4V8" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12c0 2.21 3.58 4 8 4s8-1.79 8-4" />
-                </svg>
-              </button>
-            </template>
-            <!-- Event Alert Condition Rule Icon (if rule exists for this alert's notification) -->
+            <!-- 1. Event Alert Condition Rule Icon (first, as every alert has this) -->
             <button
               v-if="alert.eventAlertConditionRule"
               @click="showRuleDetails(alert.eventAlertConditionRule!, $event)"
@@ -998,6 +1117,79 @@ defineExpose({
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
               </svg>
             </button>
+            <!-- 2. Action Icons (zapier, webhook, etc.) -->
+            <template v-if="getAlertActions(alert).length > 0">
+              <span class="text-xs" :class="isDark ? 'text-gray-500' : 'text-gray-400'">-</span>
+              <template v-for="actionItem in getAlertActions(alert)" :key="actionItem.id">
+                <!-- Zapier icon -->
+                <button
+                  v-if="actionItem.type === 'zapier'"
+                  class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
+                  :title="actionItem.name || 'Zapier action'"
+                  @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
+                >
+                  <svg class="w-3.5 h-3.5" :class="isDark ? 'text-orange-400' : 'text-orange-500'" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.894 14.025h-3.19v3.19c0 .433-.351.785-.785.785h-3.838a.786.786 0 01-.785-.785v-3.19h-3.19a.786.786 0 01-.785-.785v-2.48c0-.434.351-.785.785-.785h3.19v-3.19c0-.434.351-.785.785-.785h3.838c.434 0 .785.351.785.785v3.19h3.19c.434 0 .785.351.785.785v2.48a.786.786 0 01-.785.785z"/>
+                  </svg>
+                </button>
+                <!-- Webhook icon (hook) -->
+                <button
+                  v-else-if="actionItem.type === 'webhook'"
+                  class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
+                  :title="actionItem.name || 'Webhook action'"
+                  @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
+                >
+                  <svg class="w-3.5 h-3.5" :class="isDark ? 'text-indigo-400' : 'text-indigo-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                  </svg>
+                </button>
+                <!-- Unknown action type -->
+                <button
+                  v-else
+                  class="text-xs flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
+                  :class="isDark ? 'text-gray-400' : 'text-gray-500'"
+                  :title="actionItem.name || actionItem.type"
+                  @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
+                >
+                  {{ actionItem.type }}
+                </button>
+              </template>
+            </template>
+            <!-- 3. Notification Icons (for all notifications associated with this alert) -->
+            <template v-if="alert.notifications && alert.notifications.length > 0">
+              <template v-for="notification in alert.notifications" :key="notification.id">
+                <button
+                  v-for="action in getNotificationActions(notification)"
+                  :key="`${notification.id}-${action}`"
+                  @click="showNotificationDetails(notification, $event)"
+                  class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
+                  :title="getNotificationActionTooltip(action, notification)"
+                >
+                  <!-- Email icon -->
+                  <svg v-if="action === 'email'" class="w-3.5 h-3.5" :class="isDark ? 'text-blue-400' : 'text-blue-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                  </svg>
+                  <!-- SMS icon (chat bubble) -->
+                  <svg v-else-if="action === 'sms'" class="w-3.5 h-3.5" :class="isDark ? 'text-green-400' : 'text-green-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                  </svg>
+                  <!-- Push notification icon (bell) -->
+                  <svg v-else-if="action === 'push'" class="w-3.5 h-3.5" :class="isDark ? 'text-yellow-400' : 'text-yellow-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                  </svg>
+                  <!-- GUI icon (desktop/monitor) -->
+                  <svg v-else-if="action === 'gui'" class="w-3.5 h-3.5" :class="isDark ? 'text-cyan-400' : 'text-cyan-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                  </svg>
+                  <!-- Unknown/default icon (drum) -->
+                  <svg v-else class="w-3.5 h-3.5" :class="isDark ? 'text-gray-400' : 'text-gray-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <ellipse cx="12" cy="8" rx="8" ry="4" stroke-width="2" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8v8c0 2.21 3.58 4 8 4s8-1.79 8-4V8" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12c0 2.21 3.58 4 8 4s8-1.79 8-4" />
+                  </svg>
+                </button>
+              </template>
+            </template>
           </div>
           <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-500' : 'text-gray-400'">
             <span>{{ formatTimestamp(alert.timestamp) }}</span>
@@ -1179,6 +1371,86 @@ defineExpose({
               class="text-xs font-mono p-4 rounded overflow-auto"
               :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
             >{{ JSON.stringify(selectedRule, null, 2) }}</pre>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Action Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showActionModal && (selectedAction || selectedActionExecution)"
+        class="fixed inset-0 z-50 flex items-center justify-center"
+        @click.self="showActionModal = false"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/50" @click="showActionModal = false" />
+
+        <!-- Modal -->
+        <div
+          class="relative rounded-lg shadow-xl max-h-[80vh] flex flex-col"
+          :class="isDark ? 'bg-gray-800' : 'bg-white'"
+          style="width: 80%"
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between p-4 border-b" :class="isDark ? 'border-gray-700' : 'border-gray-200'">
+            <h3 class="text-lg font-semibold" :class="isDark ? 'text-white' : 'text-gray-800'">
+              Action: {{ selectedAction?.name || (selectedActionExecution as Record<string, unknown>)?.name || 'Unknown' }}
+            </h3>
+            <div class="flex items-center gap-2">
+              <!-- Copy Button -->
+              <button
+                @click="copyActionToClipboard"
+                class="p-1 rounded transition-colors"
+                :class="[
+                  isDark ? 'hover:bg-gray-700' : 'hover:bg-gray-100',
+                  actionCopied ? (isDark ? 'text-green-400' : 'text-green-600') : (isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-600')
+                ]"
+                :title="actionCopied ? 'Copied!' : 'Copy to clipboard'"
+              >
+                <!-- Checkmark icon when copied -->
+                <svg v-if="actionCopied" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+                <!-- Copy icon -->
+                <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </button>
+              <!-- Close Button -->
+              <button
+                @click="showActionModal = false"
+                class="p-1 rounded transition-colors"
+                :class="[
+                  isDark ? 'hover:bg-gray-700' : 'hover:bg-gray-100',
+                  isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-600'
+                ]"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Content -->
+          <div class="p-4 overflow-auto flex-1">
+            <!-- Show action definition if available -->
+            <template v-if="selectedAction">
+              <h4 class="text-sm font-semibold mb-2" :class="isDark ? 'text-gray-300' : 'text-gray-700'">Action Definition</h4>
+              <pre
+                class="text-xs font-mono p-4 rounded overflow-auto"
+                :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
+              >{{ JSON.stringify(selectedAction, null, 2) }}</pre>
+            </template>
+            <!-- Fallback to execution data if no definition found -->
+            <template v-else-if="selectedActionExecution">
+              <h4 class="text-sm font-semibold mb-2" :class="isDark ? 'text-yellow-400' : 'text-yellow-600'">Action Execution Data (definition not found)</h4>
+              <pre
+                class="text-xs font-mono p-4 rounded overflow-auto"
+                :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
+              >{{ JSON.stringify(selectedActionExecution, null, 2) }}</pre>
+            </template>
           </div>
         </div>
       </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -73,7 +73,7 @@ router.beforeEach((to, _from, next) => {
     return
   }
 
-  // Handle URL camera IDs
+  // Handle URL parameters
   // Store them in sessionStorage so they persist through the OAuth flow but not across sessions
   if (to.path === '/') {
     if (to.query.id) {
@@ -81,8 +81,21 @@ router.beforeEach((to, _from, next) => {
       sessionStorage.setItem('een_url_camera_ids', to.query.id as string)
     } else {
       // Clear stored camera IDs when accessing without ?id parameter
-      // This prevents previous session's URL cameras from being used
       sessionStorage.removeItem('een_url_camera_ids')
+    }
+
+    // Store selected camera ID
+    if (to.query.selected) {
+      sessionStorage.setItem('een_url_selected', to.query.selected as string)
+    } else {
+      sessionStorage.removeItem('een_url_selected')
+    }
+
+    // Store event type hashes
+    if (to.query.events) {
+      sessionStorage.setItem('een_url_events', to.query.events as string)
+    } else {
+      sessionStorage.removeItem('een_url_events')
     }
   }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -97,6 +97,55 @@ router.beforeEach((to, _from, next) => {
     } else {
       sessionStorage.removeItem('een_url_events')
     }
+
+    // Store events duration (ed)
+    if (to.query.ed) {
+      sessionStorage.setItem('een_url_ed', to.query.ed as string)
+    } else {
+      sessionStorage.removeItem('een_url_ed')
+    }
+
+    // Store alerts duration (ad)
+    if (to.query.ad) {
+      sessionStorage.setItem('een_url_ad', to.query.ad as string)
+    } else {
+      sessionStorage.removeItem('een_url_ad')
+    }
+
+    // Store events auto-refresh (er)
+    if (to.query.er) {
+      sessionStorage.setItem('een_url_er', to.query.er as string)
+    } else {
+      sessionStorage.removeItem('een_url_er')
+    }
+
+    // Store alerts auto-refresh (ar)
+    if (to.query.ar) {
+      sessionStorage.setItem('een_url_ar', to.query.ar as string)
+    } else {
+      sessionStorage.removeItem('een_url_ar')
+    }
+
+    // Store live events toggle (live)
+    if (to.query.live) {
+      sessionStorage.setItem('een_url_live', to.query.live as string)
+    } else {
+      sessionStorage.removeItem('een_url_live')
+    }
+
+    // Store event filter for alerts (filter)
+    if (to.query.filter) {
+      sessionStorage.setItem('een_url_filter', to.query.filter as string)
+    } else {
+      sessionStorage.removeItem('een_url_filter')
+    }
+
+    // Store dark mode (dark)
+    if (to.query.dark !== undefined) {
+      sessionStorage.setItem('een_url_dark', to.query.dark as string)
+    } else {
+      sessionStorage.removeItem('een_url_dark')
+    }
   }
 
   if (to.meta.requiresAuth && !isAuthenticated()) {

--- a/src/utils/eventTypeHash.ts
+++ b/src/utils/eventTypeHash.ts
@@ -1,0 +1,59 @@
+/**
+ * Utility for creating short URL-safe hashes of event types.
+ * Uses 3-character base62 encoding which is unique for all 60+ EEN event types.
+ */
+
+const CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+/**
+ * Generate a 3-character hash from an event type string.
+ * Uses DJB2 hash algorithm converted to base62.
+ */
+export function hashEventType(eventType: string): string {
+  let hash = 5381
+  for (let i = 0; i < eventType.length; i++) {
+    hash = ((hash << 5) + hash + eventType.charCodeAt(i)) >>> 0
+  }
+  let result = ''
+  for (let i = 0; i < 3; i++) {
+    result += CHARS[hash % 62]
+    hash = Math.floor(hash / 62)
+  }
+  return result
+}
+
+/**
+ * Build a reverse lookup map from hashes to event types.
+ * Call this once with the available event types to enable reverse lookup.
+ */
+export function buildHashLookup(eventTypes: string[]): Map<string, string> {
+  const lookup = new Map<string, string>()
+  for (const type of eventTypes) {
+    lookup.set(hashEventType(type), type)
+  }
+  return lookup
+}
+
+/**
+ * Convert an array of event types to a comma-separated hash string for URL.
+ */
+export function eventTypesToHashString(eventTypes: string[]): string {
+  return eventTypes.map(hashEventType).join(',')
+}
+
+/**
+ * Convert a comma-separated hash string from URL to event types.
+ * Returns only event types that exist in the lookup map.
+ */
+export function hashStringToEventTypes(hashString: string, lookup: Map<string, string>): string[] {
+  if (!hashString) return []
+  const hashes = hashString.split(',').map(h => h.trim()).filter(h => h.length > 0)
+  const eventTypes: string[] = []
+  for (const hash of hashes) {
+    const eventType = lookup.get(hash)
+    if (eventType) {
+      eventTypes.push(eventType)
+    }
+  }
+  return eventTypes
+}

--- a/src/views/Callback.vue
+++ b/src/views/Callback.vue
@@ -33,10 +33,17 @@ onMounted(async () => {
     return
   }
 
-  // Restore camera ID from sessionStorage if it was set before OAuth redirect
+  // Restore URL parameters from sessionStorage if they were set before OAuth redirect
   const storedCameraIds = sessionStorage.getItem('een_url_camera_ids')
-  if (storedCameraIds) {
-    router.push({ path: '/', query: { id: storedCameraIds } })
+  const storedSelected = sessionStorage.getItem('een_url_selected')
+  const storedEvents = sessionStorage.getItem('een_url_events')
+
+  if (storedCameraIds || storedSelected || storedEvents) {
+    const query: Record<string, string> = {}
+    if (storedCameraIds) query.id = storedCameraIds
+    if (storedSelected) query.selected = storedSelected
+    if (storedEvents) query.events = storedEvents
+    router.push({ path: '/', query })
   } else {
     router.push('/')
   }

--- a/src/views/Callback.vue
+++ b/src/views/Callback.vue
@@ -37,12 +37,26 @@ onMounted(async () => {
   const storedCameraIds = sessionStorage.getItem('een_url_camera_ids')
   const storedSelected = sessionStorage.getItem('een_url_selected')
   const storedEvents = sessionStorage.getItem('een_url_events')
+  const storedEd = sessionStorage.getItem('een_url_ed')
+  const storedAd = sessionStorage.getItem('een_url_ad')
+  const storedEr = sessionStorage.getItem('een_url_er')
+  const storedAr = sessionStorage.getItem('een_url_ar')
+  const storedLive = sessionStorage.getItem('een_url_live')
+  const storedFilter = sessionStorage.getItem('een_url_filter')
+  const storedDark = sessionStorage.getItem('een_url_dark')
 
-  if (storedCameraIds || storedSelected || storedEvents) {
+  if (storedCameraIds || storedSelected || storedEvents || storedEd || storedAd || storedEr || storedAr || storedLive || storedFilter || storedDark) {
     const query: Record<string, string> = {}
     if (storedCameraIds) query.id = storedCameraIds
     if (storedSelected) query.selected = storedSelected
     if (storedEvents) query.events = storedEvents
+    if (storedEd) query.ed = storedEd
+    if (storedAd) query.ad = storedAd
+    if (storedEr) query.er = storedEr
+    if (storedAr) query.ar = storedAr
+    if (storedLive) query.live = storedLive
+    if (storedFilter) query.filter = storedFilter
+    if (storedDark) query.dark = storedDark
     router.push({ path: '/', query })
   } else {
     router.push('/')

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -40,9 +40,17 @@ const initialCameraId = computed(() => {
 })
 
 // Get initial selected camera from URL query parameter
+// Only valid if the selected ID is part of the id list
 const initialSelectedCameraId = computed(() => {
   const selected = route.query.selected
-  return typeof selected === 'string' ? selected : null
+  if (typeof selected !== 'string') return null
+
+  // Validate that selected is part of the id list
+  const idParam = route.query.id
+  if (typeof idParam !== 'string') return null
+
+  const idList = idParam.split(',').map(id => id.trim())
+  return idList.includes(selected) ? selected : null
 })
 
 // Selected camera state

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -34,15 +34,27 @@ const user = ref<UserProfile | null>(null)
 const loading = ref(true)
 const error = ref<EenError | null>(null)
 
+// Parse and deduplicate comma-separated IDs
+function parseAndDedupeIds(idString: string): string[] {
+  const ids = idString.split(',').map(id => id.trim()).filter(id => id.length > 0)
+  return [...new Set(ids)]
+}
+
 // Get initial camera ID from sessionStorage (set by router guard)
 const initialCameraId = computed(() => {
   // First try sessionStorage (set by router guard before navigation)
   const stored = sessionStorage.getItem('een_url_camera_ids')
-  if (stored) return stored
+  if (stored) {
+    // Return deduplicated IDs as comma-separated string
+    return parseAndDedupeIds(stored).join(',')
+  }
 
   // Fallback to route.query
   const id = route.query.id
-  return typeof id === 'string' ? id : null
+  if (typeof id === 'string') {
+    return parseAndDedupeIds(id).join(',')
+  }
+  return null
 })
 
 // Get initial selected camera from sessionStorage
@@ -60,7 +72,7 @@ const initialSelectedCameraId = computed(() => {
   const idParam = initialCameraId.value
   if (!idParam) return null
 
-  const idList = idParam.split(',').map(id => id.trim())
+  const idList = parseAndDedupeIds(idParam)
   return idList.includes(selected) ? selected : null
 })
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, inject } from 'vue'
+import { ref, onMounted, computed, inject, watch } from 'vue'
 import type { Ref } from 'vue'
 import { getCurrentUser } from 'een-api-toolkit'
 import type { Camera } from 'een-api-toolkit'
@@ -88,6 +88,87 @@ const initialEventHashes = computed(() => {
   return typeof events === 'string' ? events : null
 })
 
+// Duration URL values mapping
+const DURATION_URL_TO_MINUTES: Record<string, number> = {
+  '10m': 10,
+  '1h': 60,
+  '24h': 1440,
+  '1w': 10080
+}
+
+const DURATION_MINUTES_TO_URL: Record<number, string> = {
+  10: '10m',
+  60: '1h',
+  1440: '24h',
+  10080: '1w'
+}
+
+// Parse duration URL value to minutes (returns null if invalid)
+function parseDurationUrl(value: string | null): number | null {
+  if (!value) return null
+  const minutes = DURATION_URL_TO_MINUTES[value]
+  return minutes !== undefined ? minutes : null
+}
+
+// Convert minutes to URL value
+function durationToUrl(minutes: number): string | null {
+  return DURATION_MINUTES_TO_URL[minutes] || null
+}
+
+// Get initial events duration from sessionStorage
+const initialEventsDuration = computed(() => {
+  const stored = sessionStorage.getItem('een_url_ed')
+  if (stored) return parseDurationUrl(stored)
+
+  const ed = route.query.ed
+  return typeof ed === 'string' ? parseDurationUrl(ed) : null
+})
+
+// Get initial alerts duration from sessionStorage
+const initialAlertsDuration = computed(() => {
+  const stored = sessionStorage.getItem('een_url_ad')
+  if (stored) return parseDurationUrl(stored)
+
+  const ad = route.query.ad
+  return typeof ad === 'string' ? parseDurationUrl(ad) : null
+})
+
+// Get initial events auto-refresh from sessionStorage (1 = enabled)
+const initialEventsAutoRefresh = computed(() => {
+  const stored = sessionStorage.getItem('een_url_er')
+  if (stored) return stored === '1'
+
+  const er = route.query.er
+  return er === '1'
+})
+
+// Get initial alerts auto-refresh from sessionStorage (1 = enabled)
+const initialAlertsAutoRefresh = computed(() => {
+  const stored = sessionStorage.getItem('een_url_ar')
+  if (stored) return stored === '1'
+
+  const ar = route.query.ar
+  return ar === '1'
+})
+
+// Get initial live events toggle from sessionStorage (1 = enabled)
+const initialLiveFeed = computed(() => {
+  const stored = sessionStorage.getItem('een_url_live')
+  if (stored) return stored === '1'
+
+  const live = route.query.live
+  return live === '1'
+})
+
+// Get initial event filter for alerts from sessionStorage (1 = enabled)
+const initialEventFilter = computed(() => {
+  const stored = sessionStorage.getItem('een_url_filter')
+  if (stored) return stored === '1'
+
+  const filter = route.query.filter
+  return filter === '1'
+})
+
 // Selected camera state
 const selectedCamera = ref<Camera | null>(null)
 
@@ -97,7 +178,19 @@ const visibleCameraIds = ref<string[]>([])
 // Current event hashes for URL (updated when event selection changes)
 const currentEventHashes = ref<string>('')
 
-// Update URL with visible cameras, selected camera, and event types
+// Current duration values for URL (updated when duration selection changes)
+const currentEventsDuration = ref<number>(60) // Default: 1h
+const currentAlertsDuration = ref<number>(60) // Default: 1h
+
+// Current auto-refresh values for URL (updated when checkbox changes)
+const currentEventsAutoRefresh = ref<boolean>(false)
+const currentAlertsAutoRefresh = ref<boolean>(false)
+
+// Current live feed and event filter values for URL
+const currentLiveFeed = ref<boolean>(false)
+const currentEventFilter = ref<boolean>(false)
+
+// Update URL with visible cameras, selected camera, event types, and durations
 function updateUrl() {
   const newQuery: Record<string, string> = {}
 
@@ -113,11 +206,53 @@ function updateUrl() {
     newQuery.events = currentEventHashes.value
   }
 
+  // Add duration parameters (only if not default value of 1h)
+  const edUrl = durationToUrl(currentEventsDuration.value)
+  if (edUrl && edUrl !== '1h') {
+    newQuery.ed = edUrl
+  }
+
+  const adUrl = durationToUrl(currentAlertsDuration.value)
+  if (adUrl && adUrl !== '1h') {
+    newQuery.ad = adUrl
+  }
+
+  // Add auto-refresh parameters (only if enabled)
+  if (currentEventsAutoRefresh.value) {
+    newQuery.er = '1'
+  }
+
+  if (currentAlertsAutoRefresh.value) {
+    newQuery.ar = '1'
+  }
+
+  // Add live feed parameter (only if enabled)
+  if (currentLiveFeed.value) {
+    newQuery.live = '1'
+  }
+
+  // Add event filter parameter (only if enabled)
+  if (currentEventFilter.value) {
+    newQuery.filter = '1'
+  }
+
+  // Add dark mode parameter (only if different from default)
+  if (isDark.value) {
+    newQuery.dark = '1'
+  }
+
   // Only update if different to avoid unnecessary history entries
   const currentId = route.query.id as string | undefined
   const currentSelected = route.query.selected as string | undefined
   const currentEvents = route.query.events as string | undefined
-  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events) {
+  const currentEd = route.query.ed as string | undefined
+  const currentAd = route.query.ad as string | undefined
+  const currentEr = route.query.er as string | undefined
+  const currentAr = route.query.ar as string | undefined
+  const currentLive = route.query.live as string | undefined
+  const currentFilter = route.query.filter as string | undefined
+  const currentDark = route.query.dark as string | undefined
+  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events || currentEd !== newQuery.ed || currentAd !== newQuery.ad || currentEr !== newQuery.er || currentAr !== newQuery.ar || currentLive !== newQuery.live || currentFilter !== newQuery.filter || currentDark !== newQuery.dark) {
     router.replace({ query: newQuery })
   }
 }
@@ -222,6 +357,42 @@ function handleEventTypesUpdate(types: string[]) {
   updateUrl()
 }
 
+// Handle events duration change
+function handleEventsDurationChange(duration: number) {
+  currentEventsDuration.value = duration
+  updateUrl()
+}
+
+// Handle alerts duration change
+function handleAlertsDurationChange(duration: number) {
+  currentAlertsDuration.value = duration
+  updateUrl()
+}
+
+// Handle events auto-refresh change
+function handleEventsAutoRefreshChange(enabled: boolean) {
+  currentEventsAutoRefresh.value = enabled
+  updateUrl()
+}
+
+// Handle alerts auto-refresh change
+function handleAlertsAutoRefreshChange(enabled: boolean) {
+  currentAlertsAutoRefresh.value = enabled
+  updateUrl()
+}
+
+// Handle live feed change
+function handleLiveFeedChange(enabled: boolean) {
+  currentLiveFeed.value = enabled
+  updateUrl()
+}
+
+// Handle event filter change
+function handleEventFilterChange(enabled: boolean) {
+  currentEventFilter.value = enabled
+  updateUrl()
+}
+
 // Handle SSE event from LiveEventsPanel - insert into HistoricEventsPanel
 function handleSseEvent(event: Record<string, unknown>) {
   historicEventsPanelRef.value?.insertEvent(event as unknown as Parameters<typeof historicEventsPanelRef.value.insertEvent>[0])
@@ -244,6 +415,11 @@ onMounted(async () => {
   }
 
   loading.value = false
+})
+
+// Watch for dark mode changes and update URL
+watch(isDark, () => {
+  updateUrl()
 })
 </script>
 
@@ -333,11 +509,15 @@ onMounted(async () => {
                 :selected-types="selectedEventTypes"
                 :is-dark="isDark"
                 :active-event-id="playbackEventId"
+                :initial-duration="initialEventsDuration"
+                :initial-auto-refresh="initialEventsAutoRefresh"
                 :live-feed-button-label="liveEventsPanelRef?.feedButtonLabel"
                 :live-feed-button-class="liveEventsPanelRef?.feedButtonClass"
                 :live-feed-can-toggle="liveEventsPanelRef?.canConnect || liveEventsPanelRef?.isConnected || liveEventsPanelRef?.isConnecting"
                 @event-clicked="handleEventClick"
                 @toggle-live-feed="liveEventsPanelRef?.toggleLiveFeed()"
+                @duration-changed="handleEventsDurationChange"
+                @auto-refresh-changed="handleEventsAutoRefreshChange"
               />
             </div>
 
@@ -349,8 +529,16 @@ onMounted(async () => {
                 :selected-types="selectedEventTypes"
                 :is-dark="isDark"
                 :active-alert-id="activeAlertId"
+                :initial-duration="initialAlertsDuration"
+                :initial-auto-refresh="initialAlertsAutoRefresh"
+                :initial-live-feed="initialLiveFeed"
+                :initial-event-filter="initialEventFilter"
                 @alert-clicked="handleAlertClick"
                 @sse-event="handleSseEvent"
+                @duration-changed="handleAlertsDurationChange"
+                @auto-refresh-changed="handleAlertsAutoRefreshChange"
+                @live-feed-changed="handleLiveFeedChange"
+                @event-filter-changed="handleEventFilterChange"
               />
             </div>
           </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -33,10 +33,16 @@ const user = ref<UserProfile | null>(null)
 const loading = ref(true)
 const error = ref<EenError | null>(null)
 
-// Get initial camera ID from URL query parameter
+// Get initial camera ID from URL query parameter (for visible cameras filter)
 const initialCameraId = computed(() => {
   const id = route.query.id
   return typeof id === 'string' ? id : null
+})
+
+// Get initial selected camera from URL query parameter
+const initialSelectedCameraId = computed(() => {
+  const selected = route.query.selected
+  return typeof selected === 'string' ? selected : null
 })
 
 // Selected camera state
@@ -45,14 +51,30 @@ const selectedCamera = ref<Camera | null>(null)
 // Visible cameras state (for URL sync)
 const visibleCameraIds = ref<string[]>([])
 
+// Update URL with both visible cameras and selected camera
+function updateUrl() {
+  const newQuery: Record<string, string> = {}
+
+  if (visibleCameraIds.value.length > 0) {
+    newQuery.id = visibleCameraIds.value.join(',')
+  }
+
+  if (selectedCamera.value) {
+    newQuery.selected = selectedCamera.value.id
+  }
+
+  // Only update if different to avoid unnecessary history entries
+  const currentId = route.query.id as string | undefined
+  const currentSelected = route.query.selected as string | undefined
+  if (currentId !== newQuery.id || currentSelected !== newQuery.selected) {
+    router.replace({ query: newQuery })
+  }
+}
+
 // Update URL when visible cameras change
 function handleVisibleCamerasChanged(cameraIds: string[]) {
   visibleCameraIds.value = cameraIds
-  const newQuery = cameraIds.length > 0 ? { id: cameraIds.join(',') } : {}
-  // Only update if different to avoid unnecessary history entries
-  if (route.query.id !== newQuery.id) {
-    router.replace({ query: newQuery })
-  }
+  updateUrl()
 }
 
 // Playback state - when an event is clicked, switch from live to recorded playback
@@ -84,6 +106,8 @@ function handleCameraSelect(camera: Camera) {
   playbackEventObject.value = null
   activeAlertId.value = null
   isAlertSource.value = false
+  // Update URL with selected camera
+  updateUrl()
 }
 
 // Handle event click - switch to recorded playback
@@ -189,6 +213,7 @@ onMounted(async () => {
       <CameraSidebar
         :selected-camera-id="selectedCameraId"
         :initial-camera-id="initialCameraId"
+        :initial-selected-camera-id="initialSelectedCameraId"
         :is-live-playback="playbackMode === 'live'"
         @select-camera="handleCameraSelect"
         @visible-cameras-changed="handleVisibleCamerasChanged"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -34,28 +34,44 @@ const user = ref<UserProfile | null>(null)
 const loading = ref(true)
 const error = ref<EenError | null>(null)
 
-// Get initial camera ID from URL query parameter (for visible cameras filter)
+// Get initial camera ID from sessionStorage (set by router guard)
 const initialCameraId = computed(() => {
+  // First try sessionStorage (set by router guard before navigation)
+  const stored = sessionStorage.getItem('een_url_camera_ids')
+  if (stored) return stored
+
+  // Fallback to route.query
   const id = route.query.id
   return typeof id === 'string' ? id : null
 })
 
-// Get initial selected camera from URL query parameter
+// Get initial selected camera from sessionStorage
 // Only valid if the selected ID is part of the id list
 const initialSelectedCameraId = computed(() => {
-  const selected = route.query.selected
-  if (typeof selected !== 'string') return null
+  // First try sessionStorage
+  let selected = sessionStorage.getItem('een_url_selected')
+  if (!selected) {
+    const querySelected = route.query.selected
+    selected = typeof querySelected === 'string' ? querySelected : null
+  }
+  if (!selected) return null
 
   // Validate that selected is part of the id list
-  const idParam = route.query.id
-  if (typeof idParam !== 'string') return null
+  const idParam = initialCameraId.value
+  if (!idParam) return null
 
   const idList = idParam.split(',').map(id => id.trim())
   return idList.includes(selected) ? selected : null
 })
 
-// Get initial event type hashes from URL query parameter
+// Get initial event type hashes from sessionStorage (set by router guard)
+// This is more reliable than route.query which may not be ready on initial render
 const initialEventHashes = computed(() => {
+  // First try sessionStorage (set by router guard before navigation)
+  const stored = sessionStorage.getItem('een_url_events')
+  if (stored) return stored
+
+  // Fallback to route.query
   const events = route.query.events
   return typeof events === 'string' ? events : null
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,7 @@ import EventTypesPanel from '../components/EventTypesPanel.vue'
 import HistoricEventsPanel from '../components/HistoricEventsPanel.vue'
 import LiveEventsPanel from '../components/LiveEventsPanel.vue'
 import type { BoundingBox } from '@/composables/useBoundingBoxes'
+import { eventTypesToHashString } from '@/utils/eventTypeHash'
 
 // Inject dark mode state
 const isDark = inject<Ref<boolean>>('isDark', ref(false))
@@ -53,13 +54,22 @@ const initialSelectedCameraId = computed(() => {
   return idList.includes(selected) ? selected : null
 })
 
+// Get initial event type hashes from URL query parameter
+const initialEventHashes = computed(() => {
+  const events = route.query.events
+  return typeof events === 'string' ? events : null
+})
+
 // Selected camera state
 const selectedCamera = ref<Camera | null>(null)
 
 // Visible cameras state (for URL sync)
 const visibleCameraIds = ref<string[]>([])
 
-// Update URL with both visible cameras and selected camera
+// Current event hashes for URL (updated when event selection changes)
+const currentEventHashes = ref<string>('')
+
+// Update URL with visible cameras, selected camera, and event types
 function updateUrl() {
   const newQuery: Record<string, string> = {}
 
@@ -71,10 +81,15 @@ function updateUrl() {
     newQuery.selected = selectedCamera.value.id
   }
 
+  if (currentEventHashes.value) {
+    newQuery.events = currentEventHashes.value
+  }
+
   // Only update if different to avoid unnecessary history entries
   const currentId = route.query.id as string | undefined
   const currentSelected = route.query.selected as string | undefined
-  if (currentId !== newQuery.id || currentSelected !== newQuery.selected) {
+  const currentEvents = route.query.events as string | undefined
+  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events) {
     router.replace({ query: newQuery })
   }
 }
@@ -174,6 +189,9 @@ const liveEventsPanelRef = ref<InstanceType<typeof LiveEventsPanel> | null>(null
 // Handle event type selection changes
 function handleEventTypesUpdate(types: string[]) {
   selectedEventTypes.value = types
+  // Update URL with event type hashes
+  currentEventHashes.value = eventTypesToHashString(types)
+  updateUrl()
 }
 
 // Handle SSE event from LiveEventsPanel - insert into HistoricEventsPanel
@@ -274,6 +292,7 @@ onMounted(async () => {
               <EventTypesPanel
                 :camera="selectedCamera"
                 :is-dark="isDark"
+                :initial-event-hashes="initialEventHashes"
                 @update:selected-types="handleEventTypesUpdate"
               />
             </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, inject, watch } from 'vue'
+import { ref, onMounted, computed, inject } from 'vue'
 import type { Ref } from 'vue'
 import { getCurrentUser } from 'een-api-toolkit'
 import type { Camera } from 'een-api-toolkit'
@@ -42,14 +42,18 @@ const initialCameraId = computed(() => {
 // Selected camera state
 const selectedCamera = ref<Camera | null>(null)
 
-// Update URL when camera selection changes
-watch(selectedCamera, (camera) => {
-  const newQuery = camera ? { id: camera.id } : {}
+// Visible cameras state (for URL sync)
+const visibleCameraIds = ref<string[]>([])
+
+// Update URL when visible cameras change
+function handleVisibleCamerasChanged(cameraIds: string[]) {
+  visibleCameraIds.value = cameraIds
+  const newQuery = cameraIds.length > 0 ? { id: cameraIds.join(',') } : {}
   // Only update if different to avoid unnecessary history entries
   if (route.query.id !== newQuery.id) {
     router.replace({ query: newQuery })
   }
-})
+}
 
 // Playback state - when an event is clicked, switch from live to recorded playback
 const playbackMode = ref<'live' | 'recorded'>('live')
@@ -187,6 +191,7 @@ onMounted(async () => {
         :initial-camera-id="initialCameraId"
         :is-live-playback="playbackMode === 'live'"
         @select-camera="handleCameraSelect"
+        @visible-cameras-changed="handleVisibleCamerasChanged"
       />
 
       <!-- Main Content Area -->

--- a/tests/cameras.spec.ts
+++ b/tests/cameras.spec.ts
@@ -307,8 +307,8 @@ test.describe('Camera Selection and Video', () => {
     const urlWithCamera = page.url()
     console.log(`URL with camera ID: ${urlWithCamera}`)
 
-    // Verify URL contains the camera ID
-    expect(urlWithCamera).toContain(`?id=${targetCameraId}`)
+    // Verify URL contains the selected camera ID (in the 'selected' parameter)
+    expect(urlWithCamera).toContain(`selected=${targetCameraId}`)
 
     // Verify main video player shows the selected camera
     const mainVideoPlayer = page.locator('.main-video-player')
@@ -337,8 +337,8 @@ test.describe('Camera Selection and Video', () => {
     const finalUrl = page.url()
     console.log(`Final URL after login: ${finalUrl}`)
 
-    // Verify the camera ID is preserved in the URL
-    expect(finalUrl).toContain(`?id=${targetCameraId}`)
+    // Verify the selected camera ID is preserved in the URL
+    expect(finalUrl).toContain(`selected=${targetCameraId}`)
 
     // Verify the correct camera is selected in the main video player
     await expect(mainVideoPlayer).toBeVisible({ timeout: TIMEOUTS.VIDEO_LOAD })

--- a/tests/url-state.spec.ts
+++ b/tests/url-state.spec.ts
@@ -194,7 +194,7 @@ test.describe('URL State Persistence', () => {
     }
 
     // Wait for URL to update with events parameter
-    await page.waitForTimeout(500)
+    await page.waitForURL(/events=/, { timeout: TIMEOUTS.UI_UPDATE })
 
     // Step 5: Capture the URL with all parameters
     const capturedUrl = page.url()

--- a/tests/url-state.spec.ts
+++ b/tests/url-state.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect, Page } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * E2E tests for URL State Persistence
+ *
+ * Tests that camera selection and event type filters are:
+ * 1. Saved to URL parameters
+ * 2. Restored when opening the app with those parameters
+ */
+
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 60000,
+  UI_UPDATE: 10000,
+  CAMERA_LOAD: 20000,
+  EVENTS_LOAD: 15000,
+  PROXY_CHECK: 5000
+} as const
+
+const TEST_USER = process.env.TEST_USER
+const TEST_PASSWORD = process.env.TEST_PASSWORD
+const PROXY_URL = process.env.VITE_PROXY_URL
+
+async function isProxyAccessible(): Promise<boolean> {
+  if (!PROXY_URL) return false
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.PROXY_CHECK)
+
+  try {
+    const response = await fetch(PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login')
+  await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+  // Wait for either EEN OAuth page or redirect back to app (if OAuth session exists)
+  await Promise.race([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.OAUTH_REDIRECT })
+  ])
+
+  // Check if we're on the EEN OAuth page or already redirected back
+  const currentUrl = page.url()
+  if (currentUrl.includes('eagleeyenetworks.com')) {
+    // Need to complete OAuth login form
+    const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(username)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill(password)
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+  }
+
+  // Wait for callback processing to complete and land on home page
+  await page.waitForFunction(
+    () => window.location.pathname === '/' && !window.location.search.includes('code='),
+    { timeout: TIMEOUTS.AUTH_COMPLETE }
+  )
+}
+
+async function clearAuthState(page: Page): Promise<void> {
+  try {
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore
+        }
+      })
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+test.describe('URL State Persistence', () => {
+  let proxyAccessible = false
+
+  function skipIfNoProxy() {
+    test.skip(!proxyAccessible, 'OAuth proxy not accessible')
+  }
+
+  function skipIfNoCredentials() {
+    test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
+  }
+
+  test.beforeAll(async () => {
+    proxyAccessible = await isProxyAccessible()
+    if (!proxyAccessible) {
+      console.log('OAuth proxy not accessible - URL state tests will be skipped')
+    }
+  })
+
+  test.afterEach(async ({ page }) => {
+    await clearAuthState(page)
+  })
+
+  test('should restore camera and event type selection from URL', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // Step 1: Login and wait for app to load
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera sidebar and cards to load
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const cameraCards = sidebar.locator('.camera-card')
+    await expect(cameraCards.first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    const cardCount = await cameraCards.count()
+    console.log(`Found ${cardCount} camera(s)`)
+
+    if (cardCount < 2) {
+      console.log('Only one camera available, test will use first camera')
+    }
+
+    // Step 2: Select the second camera (or first if only one available)
+    const targetIndex = cardCount > 1 ? 1 : 0
+    const targetCard = cameraCards.nth(targetIndex)
+    const targetCameraId = await targetCard.getAttribute('data-camera-id')
+    const targetCameraName = await targetCard.locator('h3').textContent()
+    console.log(`Selecting camera: ${targetCameraName} (ID: ${targetCameraId})`)
+
+    await targetCard.click()
+
+    // Wait for URL to update
+    await page.waitForURL(/\?id=/, { timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify main video player shows the selected camera
+    const mainVideoPlayer = page.locator('.main-video-player')
+    await expect(mainVideoPlayer).toHaveAttribute('data-camera-id', targetCameraId || '', { timeout: TIMEOUTS.UI_UPDATE })
+
+    // Step 3: Wait for event types panel to load
+    const eventTypesPanel = page.locator('.event-types-panel')
+    await expect(eventTypesPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Wait for event type checkboxes to appear
+    const checkboxes = eventTypesPanel.locator('input[type="checkbox"]')
+    await expect(checkboxes.first()).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    // Get all event type labels (skip the first one which is "All")
+    const eventTypeLabels = eventTypesPanel.locator('label')
+    const labelCount = await eventTypeLabels.count()
+    console.log(`Found ${labelCount} event type options (including All)`)
+
+    // Step 4: Toggle some event types
+    // First, get the currently selected event types
+    const initialCheckedBoxes = await eventTypesPanel.locator('input[type="checkbox"]:checked').count()
+    console.log(`Initially ${initialCheckedBoxes} event type(s) selected`)
+
+    // Click on additional event types if available (skip index 0 which is "All")
+    const eventTypesToSelect: string[] = []
+
+    // Select up to 3 event types (starting from index 1 to skip "All")
+    for (let i = 1; i < Math.min(labelCount, 4); i++) {
+      const label = eventTypeLabels.nth(i)
+      const checkbox = label.locator('input[type="checkbox"]')
+      const labelText = await label.locator('span').last().textContent()
+
+      // Check if not already checked
+      const isChecked = await checkbox.isChecked()
+      if (!isChecked) {
+        await checkbox.click()
+        console.log(`Selected event type: ${labelText}`)
+      } else {
+        console.log(`Event type already selected: ${labelText}`)
+      }
+      eventTypesToSelect.push(labelText || '')
+    }
+
+    // Wait for URL to update with events parameter
+    await page.waitForTimeout(500)
+
+    // Step 5: Capture the URL with all parameters
+    const capturedUrl = page.url()
+    console.log(`Captured URL: ${capturedUrl}`)
+
+    // Verify URL contains expected parameters
+    expect(capturedUrl).toContain('id=')
+    expect(capturedUrl).toContain('selected=')
+    expect(capturedUrl).toContain('events=')
+
+    // Get the selected event types count for verification later
+    const selectedEventTypes = await eventTypesPanel.locator('input[type="checkbox"]:checked').count()
+    // Subtract 1 if "All" checkbox is checked (it would be indeterminate or checked)
+    const selectedCount = selectedEventTypes
+    console.log(`Total selected event types: ${selectedCount}`)
+
+    // Get the selected camera ID from URL for verification
+    const urlParams = new URL(capturedUrl).searchParams
+    const urlCameraIds = urlParams.get('id')
+    const urlSelected = urlParams.get('selected')
+    const urlEvents = urlParams.get('events')
+    console.log(`URL params - id: ${urlCameraIds}, selected: ${urlSelected}, events: ${urlEvents}`)
+
+    // Step 6: Navigate away and clear session storage
+    await page.goto('/logout')
+    await expect(page.getByRole('heading', { name: /logged out/i })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Clear session storage to simulate fresh browser session
+    await page.evaluate(() => {
+      sessionStorage.clear()
+    })
+    console.log('Logged out and cleared session storage')
+
+    // Step 7: Reopen with the captured URL
+    console.log(`Reopening with URL: ${capturedUrl}`)
+    await page.goto(capturedUrl)
+
+    // Should redirect to login
+    await expect(page).toHaveURL('/login', { timeout: TIMEOUTS.UI_UPDATE })
+
+    // Login again
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Step 8: Verify URL parameters are restored
+    await page.waitForURL(/\?id=/, { timeout: TIMEOUTS.UI_UPDATE })
+    const restoredUrl = page.url()
+    console.log(`Restored URL: ${restoredUrl}`)
+
+    // Verify URL contains the same parameters
+    expect(restoredUrl).toContain(`selected=${urlSelected}`)
+    expect(restoredUrl).toContain(`events=${urlEvents}`)
+
+    // Step 9: Verify the correct camera is selected
+    await expect(mainVideoPlayer).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(mainVideoPlayer).toHaveAttribute('data-camera-id', targetCameraId || '', { timeout: TIMEOUTS.UI_UPDATE })
+    console.log(`Verified camera ${targetCameraId} is selected`)
+
+    // Step 10: Verify the event types are restored
+    await expect(eventTypesPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(checkboxes.first()).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    // Wait for event types to load
+    await page.waitForTimeout(1000)
+
+    // Count selected event types (excluding "All" checkbox if it's the first one)
+    const restoredSelectedCount = await eventTypesPanel.locator('input[type="checkbox"]:checked').count()
+    console.log(`Restored selected event types: ${restoredSelectedCount}`)
+
+    // The number of selected event types should match
+    // Note: might be fewer if some event types aren't available for this camera
+    expect(restoredSelectedCount).toBeGreaterThan(0)
+    console.log(`Event type selection restored successfully`)
+
+    console.log('URL state persistence test completed successfully')
+  })
+})


### PR DESCRIPTION
## Summary

- Add full URL state persistence for all application settings
- All parameters persist through OAuth login flow via sessionStorage
- URL automatically updates when any setting changes
- Add E2E test for URL state persistence

## URL Parameters

| Parameter | Description | Example |
|-----------|-------------|---------|
| `id` | Visible camera IDs | `id=1005963a,100f030c` |
| `selected` | Selected camera ID | `selected=100f030c` |
| `events` | Event type hashes (3-char DJB2+base62) | `events=nkU,6pF,wOj` |
| `ed` | Events duration (10m, 1h, 24h, 1w) | `ed=24h` |
| `ad` | Alerts duration (10m, 1h, 24h, 1w) | `ad=1w` |
| `er` | Events auto-refresh (1=on) | `er=1` |
| `ar` | Alerts auto-refresh (1=on) | `ar=1` |
| `live` | Live events SSE feed (1=on) | `live=1` |
| `filter` | Event filter for alerts (1=on) | `filter=1` |
| `dark` | Dark mode (1=on, 0=off) | `dark=1` |

## Example URL
```
http://127.0.0.1:3333/?id=1005963a,100f030c&selected=100f030c&events=nkU,wOj&ed=24h&live=1&dark=1
```

## Commits Included

- Add URL parameters for duration, auto-refresh, live feed, filter, and dark mode
- Only include currently visible cameras in URL
- Remove duplicate IDs when parsing URL parameters
- Add E2E test for URL state persistence
- Add event type hash documentation and update README
- Fix URL parameters not being read on initial page load
- Persist all URL parameters through OAuth flow
- Add event type hashes to URL parameters
- Preserve event type selection when switching cameras
- Validate selected parameter against id list in URL
- Add selected camera parameter to URL
- Show all visible camera IDs in URL instead of selected camera
- Add een-oauth-proxy link to prerequisites

## Test plan
- [ ] Open app with URL parameters and verify settings are applied
- [ ] Change settings and verify URL updates
- [ ] Copy URL, open in new tab, verify settings restored after login
- [ ] Run E2E tests: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)