### PR TITLE
Add EEVA reason display and include all event data schemas

### DIFF
--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -86,8 +86,41 @@ interface ListEventsParams {
   endTimestamp__lte?: string       // Optional: filter by event end time
   pageSize?: number
   pageToken?: string
-  include?: string[]               // Include SVG overlays: ['data.een.fullFrameImageUrl.v1']
+  include?: string[]               // Data schemas to include (see below)
 }
+```
+
+### Include Parameter & Data Schemas
+
+The `include` parameter controls which data schemas are populated in the `event.data[]` array.
+Include values are derived from the event's `dataSchemas` array by adding the `data.` prefix.
+
+**How it works:**
+1. Each event has a `dataSchemas` array listing available schemas (e.g., `['een.objectDetection.v1', 'een.fullFrameImageUrl.v1']`)
+2. To include that data, prefix with `data.` (e.g., `include: ['data.een.objectDetection.v1']`)
+3. Without includes, the event may return with minimal or empty `data[]`
+
+**Common data schemas:**
+| Schema | Include Value | Description |
+|--------|---------------|-------------|
+| `een.objectDetection.v1` | `data.een.objectDetection.v1` | Bounding boxes `[x1, y1, x2, y2]` (normalized 0-1) |
+| `een.objectClassification.v1` | `data.een.objectClassification.v1` | Object labels (person, vehicle, etc.) |
+| `een.fullFrameImageUrl.v1` | `data.een.fullFrameImageUrl.v1` | Full frame image URL |
+| `een.croppedFrameImageUrl.v1` | `data.een.croppedFrameImageUrl.v1` | Cropped/zoomed image URL |
+| `een.fullFrameImageUrlWithOverlay.v1` | `data.een.fullFrameImageUrlWithOverlay.v1` | Image URL with bounding box overlay |
+| `een.eevaAttributes.v1` | `data.een.eevaAttributes.v1` | EEVA analytics attributes |
+| `een.customLabels.v1` | `data.een.customLabels.v1` | Custom detection labels |
+
+**Fetching full event details:**
+```typescript
+import { getEvent } from 'een-api-toolkit'
+
+// Get event with all available data based on its dataSchemas
+const simpleEvent = events.value.find(e => e.id === eventId)
+const includes = simpleEvent?.dataSchemas.map(schema => `data.${schema}`) || []
+
+const { data: fullEvent } = await getEvent(eventId, { include: includes })
+// fullEvent.data[] now contains all available data objects
 ```
 
 ### EventMetric Interface

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/een-api-toolkit": {
-      "version": "0.3.49",
-      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.49.tgz",
-      "integrity": "sha512-s7o09qs5Jy8G3sMy6+FxRrk80QP+e9/R+IIf5EcASGPDrIqOH4jY2ouyZpZvZvcwGde2w4aveolDzQDb7oZDzQ==",
+      "version": "0.3.51",
+      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.51.tgz",
+      "integrity": "sha512-ioz2rdHoQ8beBJp/JpB2tLhBvW1lXaTBW4Lq9yIY1swehc/h+t9hbqsmKYk7/NxSfly2Ooud+JiMa47oOjClbA==",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -256,6 +256,22 @@ function getEventConfidenceCount(event: Event): number | null {
   return count > 1 ? count : null
 }
 
+// Get EEVA reason from eevaAttributes data (for eevaQueryEvent events)
+function getEevaReason(event: Event): string | null {
+  // Only for eevaQueryEvent type
+  if (event.type !== 'een.eevaQueryEvent.v1') return null
+
+  const data = event.data as Array<Record<string, unknown>> | undefined
+  if (!data || !Array.isArray(data)) return null
+
+  // Find eevaAttributes entry and extract reason
+  const eevaAttributes = data.find(item => item.type === 'een.eevaAttributes.v1')
+  if (!eevaAttributes) return null
+
+  const reason = eevaAttributes.reason as string | undefined
+  return reason || null
+}
+
 // Format timestamp for display
 function formatTimestamp(timestamp: string): string {
   const date = new Date(timestamp)
@@ -643,9 +659,13 @@ async function fetchEvents(append = false) {
     pageToken: append ? nextPageToken.value : undefined,
     sort: '-startTimestamp',
     include: [
-      'data.een.fullFrameImageUrl.v1',
       'data.een.objectDetection.v1',
-      'data.een.objectClassification.v1'
+      'data.een.objectClassification.v1',
+      'data.een.fullFrameImageUrl.v1',
+      'data.een.croppedFrameImageUrl.v1',
+      'data.een.fullFrameImageUrlWithOverlay.v1',
+      'data.een.eevaAttributes.v1',
+      'data.een.customLabels.v1'
     ]
   })
 
@@ -982,7 +1002,7 @@ watch(
     <div
       v-else
       ref="eventsContainer"
-      class="flex-1 overflow-y-auto min-h-0 space-y-1"
+      class="flex-1 overflow-y-auto overflow-x-hidden min-h-0 space-y-1"
       :class="isDark ? 'scrollbar-dark' : 'scrollbar-light'"
       @scroll="handleScroll"
     >
@@ -990,7 +1010,7 @@ watch(
         v-for="event in events"
         :key="event.id"
         :data-event-id="event.id"
-        class="relative flex items-center gap-2 p-1.5 rounded transition-colors cursor-pointer"
+        class="relative flex items-center gap-2 p-1.5 rounded transition-colors cursor-pointer overflow-hidden"
         :class="[
           activeEventId === event.id
             ? (isSseInserted(event.id)
@@ -1030,7 +1050,7 @@ watch(
         <!-- Event Info -->
         <div class="flex-1 min-w-0">
           <div class="text-xs font-medium truncate" :class="isDark ? 'text-gray-200' : 'text-gray-700'">
-            {{ getEventTypeName(event.type) }}<span v-if="getEventDuration(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> ({{ getEventDuration(event) }})</span><span v-if="getEventConfidence(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> - {{ getEventConfidence(event) }} confidence<span v-if="getEventConfidenceCount(event)"> ({{ getEventConfidenceCount(event) }})</span></span>
+            {{ getEventTypeName(event.type) }}<span v-if="getEventDuration(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> ({{ getEventDuration(event) }})</span><span v-if="getEventConfidence(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> - {{ getEventConfidence(event) }} confidence<span v-if="getEventConfidenceCount(event)"> ({{ getEventConfidenceCount(event) }})</span></span><span v-if="getEevaReason(event)" :class="isDark ? 'text-gray-400' : 'text-gray-500'"> - {{ getEevaReason(event) }}</span>
           </div>
           <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-400' : 'text-gray-400'">
             <span>{{ formatTimestamp(event.startTimestamp) }}</span>

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -328,6 +328,25 @@ watch(() => props.playbackEventObject, async (newEventObject) => {
   }
 }, { immediate: true })
 
+// Extract EEVA reason from eevaAttributes data (for eevaQueryEvent events)
+const eevaReason = computed(() => {
+  if (!props.playbackEventObject) return null
+
+  // Only show for eevaQueryEvent type
+  const eventType = props.playbackEventObject.type as string | undefined
+  if (eventType !== 'een.eevaQueryEvent.v1') return null
+
+  const data = props.playbackEventObject.data as Array<Record<string, unknown>> | undefined
+  if (!data || !Array.isArray(data)) return null
+
+  // Find eevaAttributes entry and extract reason
+  const eevaAttributes = data.find(item => item.type === 'een.eevaAttributes.v1')
+  if (!eevaAttributes) return null
+
+  const reason = eevaAttributes.reason as string | undefined
+  return reason || null
+})
+
 // Extract confidence from objectClassification data (handles multiple objects)
 const formattedConfidence = computed(() => {
   if (!props.playbackEventObject) return null
@@ -801,6 +820,10 @@ onUnmounted(() => {
           <!-- Export Error Message -->
           <div v-if="exportError" class="mt-1">
             <span class="text-xs text-red-500">{{ exportError }}</span>
+          </div>
+          <!-- EEVA Reason (for eevaQueryEvent events) -->
+          <div v-if="eevaReason" class="mt-1">
+            <span :class="isDark ? 'text-orange-400/70' : 'text-orange-600/70'" class="text-xs block leading-4">{{ eevaReason }}</span>
           </div>
           <!-- Source (if available in event data) -->
           <div v-if="formattedCreatorId" class="mt-1">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -497,7 +497,7 @@ watch(isDark, () => {
             </div>
 
             <!-- Events Panel -->
-            <div class="flex-1 border-r p-3" :class="isDark ? 'border-gray-700' : 'border-gray-200'">
+            <div class="flex-1 min-w-0 border-r p-3" :class="isDark ? 'border-gray-700' : 'border-gray-200'">
               <EventsPanel
                 ref="eventsPanelRef"
                 :camera="selectedCamera"
@@ -515,7 +515,7 @@ watch(isDark, () => {
             </div>
 
             <!-- Alerts Panel -->
-            <div class="flex-1 p-3">
+            <div class="flex-1 min-w-0 p-3">
               <AlertsPanel
                 ref="alertsPanelRef"
                 :camera="selectedCamera"


### PR DESCRIPTION
## Summary
- Include all known data schemas in `listEvents` call (`data.een.objectDetection.v1`, `data.een.objectClassification.v1`, `data.een.fullFrameImageUrl.v1`, `data.een.croppedFrameImageUrl.v1`, `data.een.fullFrameImageUrlWithOverlay.v1`, `data.een.eevaAttributes.v1`, `data.een.customLabels.v1`) for complete event data in one API call
- Display EEVA reason in Camera Information panel for `een.eevaQueryEvent.v1` events
- Show EEVA reason on Events card, truncated to fit single line
- Fix Events/Alerts panel widths with `min-w-0` for equal sizing
- Update een-api-toolkit to v0.3.51

## Test plan
- [ ] Verify EEVA events show reason text in Camera Information panel
- [ ] Verify EEVA events show truncated reason on Events card
- [ ] Verify Events and Alerts panels have equal widths
- [ ] Verify all event data is loaded correctly with new include parameters
- [ ] Run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)