### PR TITLE
Fix race conditions in event type changes and SSE reconnection

### DIFF
--- a/docs/EVENT-DATA-SCHEMAS.md
+++ b/docs/EVENT-DATA-SCHEMAS.md
@@ -1,0 +1,185 @@
+# Event Type to Data Schemas Mapping
+
+This document describes the mapping between Eagle Eye Networks event types and their associated data schemas. This mapping is used to dynamically build the `include` parameter when fetching events from the EEN API.
+
+## Overview
+
+When fetching events using the `listEvents` API, you can request additional event-specific data by using the `include` parameter. Each event type supports a specific set of data schemas. By knowing which schemas are supported by each event type, we can:
+
+1. Only request relevant data schemas for the selected event types
+2. Avoid requesting unnecessary data (reducing payload size)
+3. Ensure we get all available data for the events we're interested in
+
+## Usage
+
+The `include` parameter values must be prefixed with `data.`. For example:
+- Schema name: `een.objectDetection.v1`
+- Include value: `data.een.objectDetection.v1`
+
+### Code Usage
+
+```typescript
+import { getIncludeParameterForEventTypes } from '@/utils/eventDataSchemas'
+
+// Get include values for selected event types
+const selectedTypes = ['een.personDetectionEvent.v1', 'een.vehicleDetectionEvent.v1']
+const includeValues = getIncludeParameterForEventTypes(selectedTypes)
+
+// Result: ['data.een.objectDetection.v1', 'data.een.personAttributes.v1', ...]
+
+// Use in API call
+const result = await listEvents({
+  type__in: selectedTypes,
+  include: includeValues
+})
+```
+
+## Event Type to Data Schemas Reference
+
+### Detection Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.motionDetectionEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.displayOverlay.boundingBox.v1`, `een.fullFrameImageUrlWithOverlay.v1` |
+| `een.motionInRegionDetectionEvent.v1` | `een.motionRegion.v1`, `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.personDetectionEvent.v1` | `een.objectDetection.v1`, `een.personAttributes.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.objectRegionMapping.v1`, `een.geoLocation.v1` |
+| `een.animalDetectionEvent.v1` | `een.objectDetection.v1`, `een.animalAttributes.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.objectRegionMapping.v1` |
+| `een.faceDetectionEvent.v1` | `een.objectDetection.v1`, `een.personAttributes.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.objectRegionMapping.v1` |
+| `een.vehicleDetectionEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.vehicleAttributes.v1`, `een.objectRegionMapping.v1` |
+| `een.gunDetectionEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.motionRegion.v1`, `een.objectClassification.v1`, `een.personAttributes.v1`, `een.weaponAttributes.v1`, `een.humanValidationDetails.v1` |
+| `een.fallDetectionEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.fireDetectionEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1` |
+| `een.spillDetectionEvent.v1` | `een.objectDetection.v1`, `een.objectClassification.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.displayOverlay.boundingBox.v1`, `een.fullFrameImageUrlWithOverlay.v1` |
+| `een.crowdFormationDetectionEvent.v1` | `een.objectDetection.v1`, `een.objectClassification.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.displayOverlay.boundingBox.v1`, `een.fullFrameImageUrlWithOverlay.v1` |
+
+### Camera Analytics Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.tamperDetectionEvent.v1` | `een.fullFrameImageUrl.v1` |
+| `een.loiterDetectionEvent.v1` | `een.loiterArea.v1`, `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.objectLineCrossEvent.v1` | `een.lineCrossLine.v1`, `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.entryDirection.v1` |
+| `een.objectIntrusionEvent.v1` | `een.intrusionArea.v1`, `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.entryDirection.v1` |
+| `een.objectRemovalEvent.v1` | `een.monitoredArea.v1`, `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.personTailgateEvent.v1` | `een.objectDetection.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.ppeViolationEvent.v1` | `een.objectDetection.v1`, `een.personAttributes.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.objectRegionMapping.v1` |
+
+### AI/Scene Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.sceneLabelEvent.v1` | `een.objectDetection.v1`, `een.personAttributes.v1`, `een.vehicleAttributes.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1`, `een.objectClassification.v1`, `een.objectRegionMapping.v1`, `een.eevaAttributes.v1`, `een.customLabels.v1` |
+| `een.eevaQueryEvent.v1` | `een.eevaAttributes.v1`, `een.customLabels.v1` |
+
+### License Plate & Fleet Recognition Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.lprPlateReadEvent.v1` | `een.lprDetection.v1`, `een.lprAccessType.v1`, `een.vehicleAttributes.v1`, `een.objectDetection.v1`, `een.userData.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+| `een.fleetCodeRecognitionEvent.v1` | `een.objectDetection.v1`, `een.dotNumberRecognition.v1`, `een.truckNumberRecognition.v1`, `een.trailerNumberRecognition.v1`, `een.recognizedText.v1`, `een.croppedFrameImageUrl.v1`, `een.fullFrameImageUrl.v1` |
+
+### Audio Detection Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.gunShotAudioDetectionEvent.v1` | `een.audioDetection.v1`, `een.geoLocation.v1` |
+| `een.t3AlarmAudioDetectionEvent.v1` | `een.audioDetection.v1` |
+| `een.t4AlarmAudioDetectionEvent.v1` | `een.audioDetection.v1` |
+
+### POS (Point of Sale) Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.posTransactionEvent.v1` | `een.posTransactionStart.v1`, `een.posTransactionEnd.v1`, `een.posTransactionItem.v1`, `een.posTransactionPayment.v1`, `een.posTransactionCartChangeTrail.v1`, `een.posTransactionCardLoadSummary.v1`, `een.posTransactionFlag.v1`, `een.posTransactionLabel.v1` |
+
+### Device & System Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.deviceCloudStatusUpdateEvent.v1` | `een.deviceCloudStatusUpdate.v1`, `een.deviceCloudPreviousStatus.v1` |
+| `een.deviceIOEvent.v1` | `een.deviceIO.v1` |
+| `een.deviceOperationEvent.v1` | `een.deviceOperationDetails.v1`, `een.deviceOperationSubStep.v1` |
+| `een.ptzPositionUpdateEvent.v1` | `een.ptzPositionUpdate.v1` |
+
+### Sensor Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.doorStatusEvent.v1` | `een.measurementStringValueUpdate.v1` |
+| `een.batteryLevelUpdateEvent.v1` | `een.batteryLevelUpdate.v1` |
+| `een.measurementThresholdStatusEvent.v1` | `een.measurementThresholdStatus.v1`, `een.measurementValueUpdate.v1` |
+| `een.thermalCameraThresholdStatusEvent.v1` | `een.thermalCameraValueUpdate.v1`, `een.thermalMonitoredArea.v1` |
+
+### Resource Management Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.layoutCreationEvent.v1` | `een.resourceDetails.v1` |
+| `een.layoutUpdateEvent.v1` | `een.resourceDetails.v1` |
+| `een.layoutDeletionEvent.v1` | `een.resourceDetails.v1` |
+| `een.deviceCreationEvent.v1` | `een.resourceDetails.v1` |
+| `een.deviceUpdateEvent.v1` | `een.resourceDetails.v1` |
+| `een.deviceDeletionEvent.v1` | `een.resourceDetails.v1` |
+| `een.userCreationEvent.v1` | `een.resourceDetails.v1` |
+| `een.userUpdateEvent.v1` | `een.resourceDetails.v1` |
+| `een.userDeletionEvent.v1` | `een.resourceDetails.v1` |
+| `een.accountCreationEvent.v1` | `een.resourceDetails.v1` |
+| `een.accountUpdateEvent.v1` | `een.resourceDetails.v1` |
+| `een.accountDeletionEvent.v1` | `een.resourceDetails.v1` |
+
+### Job Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.jobCreationEvent.v1` | `een.jobDetails.v1`, `een.ownerDetails.v1` |
+| `een.jobUpdateEvent.v1` | `een.jobDetails.v1`, `een.ownerDetails.v1` |
+| `een.jobDeletionEvent.v1` | `een.ownerDetails.v1` |
+
+### Safety & Protocol Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.panicButtonEvent.v1` | `een.geoLocation.v1` |
+| `een.evacuateProtocolEvent.v1` | *(none)* |
+| `een.holdProtocolEvent.v1` | *(none)* |
+| `een.lockdownProtocolEvent.v1` | *(none)* |
+| `een.secureProtocolEvent.v1` | *(none)* |
+| `een.shelterProtocolEvent.v1` | *(none)* |
+
+### Behavioral Events
+
+| Event Type | Data Schemas |
+|------------|--------------|
+| `een.violenceDetectionEvent.v1` | *(none)* |
+| `een.fightDetectionEvent.v1` | *(none)* |
+| `een.handsUpDetectionEvent.v1` | *(none)* |
+| `een.vapeDetectionEvent.v1` | *(none)* |
+
+## Common Data Schemas
+
+These are the most commonly used data schemas across multiple event types:
+
+| Schema | Description | Used By |
+|--------|-------------|---------|
+| `een.objectDetection.v1` | Bounding box and object tracking info | Most detection events |
+| `een.objectClassification.v1` | Object class (person, vehicle, etc.) and confidence | Detection events with classification |
+| `een.fullFrameImageUrl.v1` | URL to full-frame event image | Most camera events |
+| `een.croppedFrameImageUrl.v1` | URL to cropped image of detected object | Detection events |
+| `een.personAttributes.v1` | Person-specific attributes (clothing, gender) | Person detection events |
+| `een.vehicleAttributes.v1` | Vehicle-specific attributes (make, model, color) | Vehicle detection events |
+| `een.eevaAttributes.v1` | EEVA AI query and response attributes | Scene label and EEVA query events |
+| `een.customLabels.v1` | Custom labels from AI analysis | Scene label and EEVA query events |
+
+## Source
+
+This mapping is derived from the Eagle Eye Networks API v3.0 specification:
+- File: `api-v3-documentation/api/3.0/events.yaml`
+- Section: `dataSchemas` within each event type example
+
+## Maintenance
+
+When new event types are added to the EEN API:
+1. Check the `events.yaml` specification for the new event type
+2. Find the `dataSchemas` array in the event example
+3. Add the mapping to `src/utils/eventDataSchemas.ts`
+4. Update this documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -73,12 +73,13 @@ const SUBSCRIPTION_TTL_MS = 14 * 60 * 1000 // Reconnect at 14 minutes
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let isProactiveReconnecting = false
 
-// Debounce timer for event type changes
-const DEBOUNCE_DELAY_MS = 500
-let debounceTimer: ReturnType<typeof setTimeout> | null = null
+// Debounce timer for event type changes (used for both fetch and SSE)
+const CHANGE_DEBOUNCE_MS = 500
+let changeDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
-// Connection guard - tracks current connection attempt to prevent races
+// Request versioning - tracks current requests to discard stale results
 let connectionAttemptId = 0
+let fetchRequestId = 0
 
 // Refs
 const eventsContainer = ref<HTMLElement | null>(null)
@@ -381,11 +382,11 @@ function mergeEvents(newEvents: Event[], previousViewportOffset: number | null =
   }
 }
 
-// Insert a single event from SSE
-function insertEvent(event: Event): void {
+// Insert a single event from SSE - returns true if event was inserted
+function insertEvent(event: Event): boolean {
   // Only insert if event type matches selected types
   if (!props.selectedTypes.includes(event.type)) {
-    return
+    return false
   }
 
   // Get active event's viewport position BEFORE the merge
@@ -393,6 +394,7 @@ function insertEvent(event: Event): void {
   // Track this event as SSE-inserted (will show with blue background)
   sseInsertedIds.value.add(event.id)
   mergeEvents([event], viewportOffset)
+  return true
 }
 
 // ==================== SSE FUNCTIONALITY ====================
@@ -417,9 +419,11 @@ function toggleLiveFeed() {
 // Handle new SSE event
 function handleSseEvent(event: SSEEvent) {
   const typedEvent = event as unknown as Event
-  insertEvent(typedEvent)
-  // Show notification with event type name
-  showNotification(getEventTypeName(typedEvent.type))
+  const wasInserted = insertEvent(typedEvent)
+  // Only show notification if event was actually inserted (matched selected types)
+  if (wasInserted) {
+    showNotification(getEventTypeName(typedEvent.type))
+  }
 }
 
 // Clear the reconnect timer
@@ -430,11 +434,11 @@ function clearReconnectTimer() {
   }
 }
 
-// Clear the debounce timer
-function clearDebounceTimer() {
-  if (debounceTimer) {
-    clearTimeout(debounceTimer)
-    debounceTimer = null
+// Clear the change debounce timer
+function clearChangeDebounceTimer() {
+  if (changeDebounceTimer) {
+    clearTimeout(changeDebounceTimer)
+    changeDebounceTimer = null
   }
 }
 
@@ -597,7 +601,7 @@ async function disconnect() {
   connectionAttemptId++
 
   clearReconnectTimer()
-  clearDebounceTimer()
+  clearChangeDebounceTimer()
 
   if (sseConnection.value) {
     sseConnection.value.close()
@@ -613,31 +617,45 @@ async function disconnect() {
   connectionError.value = null
 }
 
-// Debounced reconnection handler
-async function debouncedReconnect(cameraId: string, types: string[]) {
-  clearDebounceTimer()
+// Unified debounced handler for event type/camera changes
+// Handles both fetchEvents and SSE reconnection with a single debounce
+async function debouncedRefreshAndReconnect() {
+  clearChangeDebounceTimer()
 
+  // Immediately invalidate any in-flight fetch requests
+  fetchRequestId++
+
+  // Immediately disconnect SSE to stop receiving events for old types
   const wasConnected = isConnected.value || isConnecting.value
   if (wasConnected) {
     await disconnect()
   }
 
-  if (types.length === 0 || !liveFeedEnabled.value) {
-    return
-  }
+  // Immediately filter existing events by new selected types
+  filterEventsBySelectedTypes()
 
-  debounceTimer = setTimeout(async () => {
-    debounceTimer = null
-    if (props.camera?.id === cameraId && props.selectedTypes.length > 0 && liveFeedEnabled.value) {
+  // Debounce the actual refresh and reconnect
+  changeDebounceTimer = setTimeout(async () => {
+    changeDebounceTimer = null
+
+    // Fetch events if we have camera and types
+    if (props.camera && props.selectedTypes.length > 0) {
+      await fetchEvents()
+    }
+
+    // Reconnect SSE if live feed is enabled and not already connected
+    // (guards against race with auto-reconnect timer)
+    if (props.camera && props.selectedTypes.length > 0 && liveFeedEnabled.value &&
+        !isConnected.value && !isConnecting.value) {
       await connect()
     }
-  }, DEBOUNCE_DELAY_MS)
+  }, CHANGE_DEBOUNCE_MS)
 }
 
 // Expose events for parent component
 defineExpose({ events })
 
-// Fetch historic events
+// Fetch historic events with request versioning to discard stale results
 async function fetchEvents(append = false) {
   if (!props.camera || props.selectedTypes.length === 0) {
     events.value = []
@@ -645,14 +663,22 @@ async function fetchEvents(append = false) {
     return
   }
 
+  // Increment request ID to track this request
+  fetchRequestId++
+  const currentRequestId = fetchRequestId
+
+  // Capture current state at request time for validation
+  const requestCameraId = props.camera.id
+  const requestTypes = [...props.selectedTypes]
+
   loading.value = true
   if (!append) {
     error.value = null
   }
 
   const result = await listEvents({
-    actor: `camera:${props.camera.id}`,
-    type__in: props.selectedTypes,
+    actor: `camera:${requestCameraId}`,
+    type__in: requestTypes,
     startTimestamp__gte: getStartTimestamp(),
     endTimestamp__lte: new Date().toISOString(),
     pageSize: 100,
@@ -668,6 +694,22 @@ async function fetchEvents(append = false) {
       'data.een.customLabels.v1'
     ]
   })
+
+  // Discard results if a newer request was made or state changed
+  if (currentRequestId !== fetchRequestId) {
+    loading.value = false
+    return // Stale request - discard results
+  }
+
+  // Validate that camera and types still match what we requested
+  const typesMatch = props.camera?.id === requestCameraId &&
+    props.selectedTypes.length === requestTypes.length &&
+    props.selectedTypes.every(t => requestTypes.includes(t))
+
+  if (!typesMatch) {
+    loading.value = false
+    return // State changed during request - discard results
+  }
 
   if (result.error) {
     error.value = result.error
@@ -859,22 +901,32 @@ onUnmounted(async () => {
 // Initialize event type names
 fetchEventTypeNames()
 
-// Watch for camera changes - clear and fetch
+// Watch for camera or selected types changes - unified debounced handler
+// This ensures fetchEvents and SSE reconnection are always in sync
 watch(
-  () => props.camera?.id,
-  () => {
-    events.value = []
-    sseInsertedIds.value.clear()
-    fetchEvents()
-  }
-)
+  [() => props.camera?.id, () => props.selectedTypes],
+  ([newCameraId, newTypes], [oldCameraId, oldTypes]) => {
+    const cameraChanged = newCameraId !== oldCameraId
+    const typesChanged = JSON.stringify(newTypes) !== JSON.stringify(oldTypes)
 
-// Watch for selected types changes - filter existing events then fetch
-watch(
-  () => props.selectedTypes,
-  () => {
-    filterEventsBySelectedTypes()
-    fetchEvents()
+    if (!cameraChanged && !typesChanged) {
+      return
+    }
+
+    // Clear events on camera change
+    if (cameraChanged) {
+      events.value = []
+      sseInsertedIds.value.clear()
+    }
+
+    // Use unified debounced handler for both fetch and SSE
+    if (newCameraId && newTypes && newTypes.length > 0) {
+      debouncedRefreshAndReconnect()
+    } else {
+      // No camera or no types - clear state and disconnect
+      filterEventsBySelectedTypes()
+      disconnect()
+    }
   },
   { immediate: true, deep: true }
 )
@@ -886,27 +938,6 @@ watch(
     fetchEvents()
     emit('duration-changed', newValue)
   }
-)
-
-// Watch for camera or selected types changes - reconnect SSE with debouncing
-watch(
-  [() => props.camera?.id, () => props.selectedTypes],
-  ([newCameraId, newTypes], [oldCameraId, oldTypes]) => {
-    const cameraChanged = newCameraId !== oldCameraId
-    const typesChanged = JSON.stringify(newTypes) !== JSON.stringify(oldTypes)
-
-    if (!cameraChanged && !typesChanged) {
-      return
-    }
-
-    // Use debounced reconnection for SSE
-    if (newCameraId && newTypes) {
-      debouncedReconnect(newCameraId, newTypes)
-    } else if (!newCameraId || newTypes.length === 0) {
-      disconnect()
-    }
-  },
-  { deep: true }
 )
 </script>
 

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -12,6 +12,7 @@ import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
 import { useSseNotification } from '@/composables/useSseNotification'
 import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
+import { getIncludeParameterForEventTypes } from '@/utils/eventDataSchemas'
 import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
@@ -676,6 +677,9 @@ async function fetchEvents(append = false) {
     error.value = null
   }
 
+  // Build dynamic include parameter based on selected event types
+  const includeSchemas = getIncludeParameterForEventTypes(requestTypes)
+
   const result = await listEvents({
     actor: `camera:${requestCameraId}`,
     type__in: requestTypes,
@@ -684,15 +688,7 @@ async function fetchEvents(append = false) {
     pageSize: 100,
     pageToken: append ? nextPageToken.value : undefined,
     sort: '-startTimestamp',
-    include: [
-      'data.een.objectDetection.v1',
-      'data.een.objectClassification.v1',
-      'data.een.fullFrameImageUrl.v1',
-      'data.een.croppedFrameImageUrl.v1',
-      'data.een.fullFrameImageUrlWithOverlay.v1',
-      'data.een.eevaAttributes.v1',
-      'data.een.customLabels.v1'
-    ]
+    include: includeSchemas
   })
 
   // Discard results if a newer request was made or state changed

--- a/src/utils/eventDataSchemas.ts
+++ b/src/utils/eventDataSchemas.ts
@@ -1,0 +1,420 @@
+/**
+ * Event Type to Data Schemas Mapping
+ *
+ * This module provides a mapping between EEN event types and their associated data schemas.
+ * The mapping is derived from the Eagle Eye Networks API v3.0 events.yaml specification.
+ *
+ * When fetching events with the `include` parameter, you must prefix schemas with "data."
+ * For example: "een.objectDetection.v1" becomes "data.een.objectDetection.v1"
+ *
+ * @see docs/EVENT-DATA-SCHEMAS.md for full documentation
+ */
+
+/**
+ * Complete mapping of event types to their supported data schemas.
+ * Each key is an event type (e.g., "een.motionDetectionEvent.v1")
+ * and each value is an array of data schema names that can be included
+ * when fetching that event type.
+ */
+export const EVENT_TYPE_DATA_SCHEMAS: Record<string, string[]> = {
+  // Device & System Events
+  'een.deviceCloudStatusUpdateEvent.v1': [
+    'een.deviceCloudStatusUpdate.v1',
+    'een.deviceCloudPreviousStatus.v1'
+  ],
+
+  // Motion Detection Events
+  'een.motionDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.displayOverlay.boundingBox.v1',
+    'een.fullFrameImageUrlWithOverlay.v1'
+  ],
+
+  'een.motionInRegionDetectionEvent.v1': [
+    'een.motionRegion.v1',
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  // License Plate Recognition Events
+  'een.lprPlateReadEvent.v1': [
+    'een.lprDetection.v1',
+    'een.lprAccessType.v1',
+    'een.vehicleAttributes.v1',
+    'een.objectDetection.v1',
+    'een.userData.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  // Camera Analytics Events
+  'een.tamperDetectionEvent.v1': [
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  'een.loiterDetectionEvent.v1': [
+    'een.loiterArea.v1',
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  'een.objectLineCrossEvent.v1': [
+    'een.lineCrossLine.v1',
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.entryDirection.v1'
+  ],
+
+  'een.objectIntrusionEvent.v1': [
+    'een.intrusionArea.v1',
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.entryDirection.v1'
+  ],
+
+  // POS (Point of Sale) Events
+  'een.posTransactionEvent.v1': [
+    'een.posTransactionStart.v1',
+    'een.posTransactionEnd.v1',
+    'een.posTransactionItem.v1',
+    'een.posTransactionPayment.v1',
+    'een.posTransactionCartChangeTrail.v1',
+    'een.posTransactionCardLoadSummary.v1',
+    'een.posTransactionFlag.v1',
+    'een.posTransactionLabel.v1'
+  ],
+
+  // Behavioral Detection Events (no data schemas)
+  'een.violenceDetectionEvent.v1': [],
+  'een.fightDetectionEvent.v1': [],
+  'een.handsUpDetectionEvent.v1': [],
+
+  // Sensor Events
+  'een.doorStatusEvent.v1': [
+    'een.measurementStringValueUpdate.v1'
+  ],
+
+  'een.batteryLevelUpdateEvent.v1': [
+    'een.batteryLevelUpdate.v1'
+  ],
+
+  'een.measurementThresholdStatusEvent.v1': [
+    'een.measurementThresholdStatus.v1',
+    'een.measurementValueUpdate.v1'
+  ],
+
+  // Object Detection Events
+  'een.personDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.personAttributes.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.objectRegionMapping.v1',
+    'een.geoLocation.v1'
+  ],
+
+  'een.animalDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.animalAttributes.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.objectRegionMapping.v1'
+  ],
+
+  'een.faceDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.personAttributes.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.objectRegionMapping.v1'
+  ],
+
+  'een.ppeViolationEvent.v1': [
+    'een.objectDetection.v1',
+    'een.personAttributes.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.objectRegionMapping.v1'
+  ],
+
+  'een.vehicleDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.vehicleAttributes.v1',
+    'een.objectRegionMapping.v1'
+  ],
+
+  // Scene & AI Events
+  'een.sceneLabelEvent.v1': [
+    'een.objectDetection.v1',
+    'een.personAttributes.v1',
+    'een.vehicleAttributes.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1',
+    'een.objectRegionMapping.v1',
+    'een.eevaAttributes.v1',
+    'een.customLabels.v1'
+  ],
+
+  'een.eevaQueryEvent.v1': [
+    'een.eevaAttributes.v1',
+    'een.customLabels.v1'
+  ],
+
+  // Gun Detection Events
+  'een.gunDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.motionRegion.v1',
+    'een.objectClassification.v1',
+    'een.personAttributes.v1',
+    'een.weaponAttributes.v1',
+    'een.humanValidationDetails.v1'
+  ],
+
+  // Audio Detection Events
+  'een.gunShotAudioDetectionEvent.v1': [
+    'een.audioDetection.v1',
+    'een.geoLocation.v1'
+  ],
+
+  'een.t3AlarmAudioDetectionEvent.v1': [
+    'een.audioDetection.v1'
+  ],
+
+  'een.t4AlarmAudioDetectionEvent.v1': [
+    'een.audioDetection.v1'
+  ],
+
+  // Resource Management Events (Layout, Device, User, Account)
+  'een.layoutCreationEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.layoutUpdateEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.layoutDeletionEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.deviceCreationEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.deviceUpdateEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.deviceDeletionEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.userCreationEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.userUpdateEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.userDeletionEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.accountCreationEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.accountUpdateEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  'een.accountDeletionEvent.v1': [
+    'een.resourceDetails.v1'
+  ],
+
+  // PTZ Events
+  'een.ptzPositionUpdateEvent.v1': [
+    'een.ptzPositionUpdate.v1'
+  ],
+
+  // Job Events
+  'een.jobCreationEvent.v1': [
+    'een.jobDetails.v1',
+    'een.ownerDetails.v1'
+  ],
+
+  'een.jobUpdateEvent.v1': [
+    'een.jobDetails.v1',
+    'een.ownerDetails.v1'
+  ],
+
+  'een.jobDeletionEvent.v1': [
+    'een.ownerDetails.v1'
+  ],
+
+  // Advanced Detection Events
+  'een.objectRemovalEvent.v1': [
+    'een.monitoredArea.v1',
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  'een.fallDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  'een.personTailgateEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  // Device I/O Events
+  'een.deviceIOEvent.v1': [
+    'een.deviceIO.v1'
+  ],
+
+  'een.deviceOperationEvent.v1': [
+    'een.deviceOperationDetails.v1',
+    'een.deviceOperationSubStep.v1'
+  ],
+
+  // Thermal Camera Events
+  'een.thermalCameraThresholdStatusEvent.v1': [
+    'een.thermalCameraValueUpdate.v1',
+    'een.thermalMonitoredArea.v1'
+  ],
+
+  // Safety Protocol Events (no data schemas)
+  'een.evacuateProtocolEvent.v1': [],
+  'een.holdProtocolEvent.v1': [],
+  'een.lockdownProtocolEvent.v1': [],
+  'een.secureProtocolEvent.v1': [],
+  'een.shelterProtocolEvent.v1': [],
+
+  // Panic Button Event
+  'een.panicButtonEvent.v1': [
+    'een.geoLocation.v1'
+  ],
+
+  // Vape Detection Event (no data schemas)
+  'een.vapeDetectionEvent.v1': [],
+
+  // Fleet Code Recognition Event
+  'een.fleetCodeRecognitionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.dotNumberRecognition.v1',
+    'een.truckNumberRecognition.v1',
+    'een.trailerNumberRecognition.v1',
+    'een.recognizedText.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1'
+  ],
+
+  // Spill Detection Event
+  'een.spillDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.objectClassification.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.displayOverlay.boundingBox.v1',
+    'een.fullFrameImageUrlWithOverlay.v1'
+  ],
+
+  // Crowd Formation Detection Event
+  'een.crowdFormationDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.objectClassification.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.displayOverlay.boundingBox.v1',
+    'een.fullFrameImageUrlWithOverlay.v1'
+  ],
+
+  // Fire Detection Event
+  'een.fireDetectionEvent.v1': [
+    'een.objectDetection.v1',
+    'een.croppedFrameImageUrl.v1',
+    'een.fullFrameImageUrl.v1',
+    'een.objectClassification.v1'
+  ]
+}
+
+/**
+ * Get the data schemas for a specific event type.
+ * @param eventType - The event type (e.g., "een.motionDetectionEvent.v1")
+ * @returns Array of data schema names, or empty array if event type is unknown
+ */
+export function getDataSchemasForEventType(eventType: string): string[] {
+  return EVENT_TYPE_DATA_SCHEMAS[eventType] || []
+}
+
+/**
+ * Get the combined, deduplicated data schemas for multiple event types.
+ * Returns an array of schema names prefixed with "data." for use with the
+ * listEvents API `include` parameter.
+ *
+ * @param eventTypes - Array of event types to get schemas for
+ * @returns Array of unique schema names prefixed with "data." (e.g., "data.een.objectDetection.v1")
+ */
+export function getIncludeParameterForEventTypes(eventTypes: string[]): string[] {
+  const schemasSet = new Set<string>()
+
+  for (const eventType of eventTypes) {
+    const schemas = EVENT_TYPE_DATA_SCHEMAS[eventType]
+    if (schemas) {
+      for (const schema of schemas) {
+        schemasSet.add(schema)
+      }
+    }
+  }
+
+  // Convert to array and prefix with "data."
+  return Array.from(schemasSet).map(schema => `data.${schema}`)
+}
+
+/**
+ * Get all unique data schemas across all event types.
+ * Useful for debugging or understanding the full scope of available schemas.
+ *
+ * @returns Array of all unique data schema names (without "data." prefix)
+ */
+export function getAllUniqueDataSchemas(): string[] {
+  const schemasSet = new Set<string>()
+
+  for (const schemas of Object.values(EVENT_TYPE_DATA_SCHEMAS)) {
+    for (const schema of schemas) {
+      schemasSet.add(schema)
+    }
+  }
+
+  return Array.from(schemasSet).sort()
+}
+
+/**
+ * Get all known event types.
+ * @returns Array of all event type names
+ */
+export function getAllEventTypes(): string[] {
+  return Object.keys(EVENT_TYPE_DATA_SCHEMAS).sort()
+}


### PR DESCRIPTION
## Summary
- Fix SSE notification showing for filtered events (only notify when event is actually inserted)
- Add request versioning to `fetchEvents()` to discard stale API results
- Unify debounce handling for both fetch and SSE reconnection (500ms)
- Invalidate in-flight requests immediately when debounce resets
- Reset loading state when discarding stale results
- Guard against duplicate SSE connections from auto-reconnect race
- Consolidate watchers for camera/types changes into single handler

## Test plan
- [ ] Rapidly toggle event types and verify no stale events appear
- [ ] Verify SSE notifications only show for selected event types
- [ ] Verify loading spinner doesn't get stuck
- [ ] Verify no duplicate SSE connections during error recovery
- [ ] Run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)