### PR TITLE
Add alert enhancements, image cache fix, and UI improvements

### DIFF
--- a/.claude/agents/een-devices-agent.md.backup
+++ b/.claude/agents/een-devices-agent.md.backup
@@ -69,14 +69,14 @@ interface Camera {
 type CameraStatus =
   | 'online'
   | 'offline'
-  | 'streaming'
-  | 'recording'
-  | 'registered'
   | 'deviceOffline'
   | 'bridgeOffline'
   | 'invalidCredentials'
   | 'error'
-  | 'unknown'
+  | 'streaming'
+  | 'registered'
+  | 'attaching'
+  | 'initializing'
 
 // Status can also be nested in an object:
 // camera.status?.connectionStatus
@@ -97,7 +97,10 @@ type BridgeStatus =
   | 'online'
   | 'offline'
   | 'error'
-  | 'unknown'
+  | 'idle'
+  | 'registered'
+  | 'attaching'
+  | 'initializing'
 ```
 
 ### ListCamerasParams
@@ -141,7 +144,7 @@ async function fetchCameras() {
 async function fetchOnlineCameras() {
   const result = await getCameras({
     include: ['status'],  // Required to display status in UI
-    status__in: ['online', 'streaming', 'recording'],
+    status__in: ['online', 'streaming', 'registered'],
     pageSize: 100
   })
 
@@ -249,7 +252,7 @@ import { getCameras, type Camera, type CameraStatus, type ListCamerasParams } fr
 
 const cameras = ref<Camera[]>([])
 const loading = ref(false)
-const statusFilter = ref<string[]>(['online', 'streaming', 'recording'])
+const statusFilter = ref<string[]>(['online', 'streaming', 'registered'])
 
 // Helper: status can be a string OR an object with connectionStatus
 function getStatusString(status?: CameraStatus | { connectionStatus?: CameraStatus }): string | undefined {

--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -316,6 +316,7 @@ import { listAlerts, type Alert, type ListAlertsParams } from 'een-api-toolkit'
 async function fetchAlerts() {
   const result = await listAlerts({
     status__in: ['active', 'acknowledged'],
+    include: ['data', 'actions', 'dataSchemas', 'description'],
     pageSize: 20
   })
 
@@ -324,6 +325,13 @@ async function fetchAlerts() {
   }
 }
 ```
+
+#### Alert Include Parameter
+The `include` parameter controls what additional data is returned with each alert:
+- `'data'` - Include alert data objects (varies by alert type)
+- `'actions'` - Include actions executed for this alert
+- `'dataSchemas'` - Include list of data schema types
+- `'description'` - Include human-readable description
 
 ### Alert Priority
 Alert priority is an integer value ranging from **0 to 10**:

--- a/.claude/agents/een-events-agent.md.backup
+++ b/.claude/agents/een-events-agent.md.backup
@@ -38,6 +38,7 @@ assistant: "I'll use the een-events-agent to help set up SSE (Server-Sent Events
 - docs/ai-reference/AI-AUTH.md (auth is required)
 - docs/ai-reference/AI-DEVICES.md (events are per-camera)
 - docs/ai-reference/AI-EVENTS.md (primary reference)
+- docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md (event type to data schema mapping)
 
 ## Reference Examples
 - examples/vue-events/ (Event listing with bounding boxes)
@@ -52,6 +53,8 @@ assistant: "I'll use the een-events-agent to help set up SSE (Server-Sent Events
 5. List notifications with listNotifications()
 6. Create SSE subscriptions with createEventSubscription()
 7. Connect to real-time streams with connectToEventSubscription()
+8. Build dynamic include parameters with getIncludeParameterForEventTypes()
+9. Map event types to data schemas with EVENT_TYPE_DATA_SCHEMAS
 
 ## Key Types
 
@@ -79,14 +82,83 @@ type EventType =
 ```typescript
 interface ListEventsParams {
   actor: string                    // Required: "camera:{cameraId}"
-  startTimestamp?: string
-  endTimestamp?: string
-  type__in?: EventType[]
+  type__in: string[]               // Required: event types to query
+  startTimestamp__gte: string      // Required: start time (ISO 8601)
+  startTimestamp__lte?: string     // Optional: end time filter
+  endTimestamp__gte?: string       // Optional: filter by event end time
+  endTimestamp__lte?: string       // Optional: filter by event end time
   pageSize?: number
   pageToken?: string
-  include?: string[]               // Include SVG overlays: ['data.overlays']
+  include?: string[]               // Data schemas to include (see below)
 }
 ```
+
+### Include Parameter & Data Schemas
+
+The `include` parameter controls which data schemas are populated in the `event.data[]` array.
+Include values are derived from the event's `dataSchemas` array by adding the `data.` prefix.
+
+**How it works:**
+1. Each event has a `dataSchemas` array listing available schemas (e.g., `['een.objectDetection.v1', 'een.fullFrameImageUrl.v1']`)
+2. To include that data, prefix with `data.` (e.g., `include: ['data.een.objectDetection.v1']`)
+3. Without includes, the event may return with minimal or empty `data[]`
+
+**Common data schemas:**
+| Schema | Include Value | Description |
+|--------|---------------|-------------|
+| `een.objectDetection.v1` | `data.een.objectDetection.v1` | Bounding boxes `[x1, y1, x2, y2]` (normalized 0-1) |
+| `een.objectClassification.v1` | `data.een.objectClassification.v1` | Object labels (person, vehicle, etc.) |
+| `een.fullFrameImageUrl.v1` | `data.een.fullFrameImageUrl.v1` | Full frame image URL |
+| `een.croppedFrameImageUrl.v1` | `data.een.croppedFrameImageUrl.v1` | Cropped/zoomed image URL |
+| `een.fullFrameImageUrlWithOverlay.v1` | `data.een.fullFrameImageUrlWithOverlay.v1` | Image URL with bounding box overlay |
+| `een.eevaAttributes.v1` | `data.een.eevaAttributes.v1` | EEVA analytics attributes |
+| `een.customLabels.v1` | `data.een.customLabels.v1` | Custom detection labels |
+
+**Fetching full event details:**
+```typescript
+import { getEvent } from 'een-api-toolkit'
+
+// Get event with all available data based on its dataSchemas
+const simpleEvent = events.value.find(e => e.id === eventId)
+const includes = simpleEvent?.dataSchemas.map(schema => `data.${schema}`) || []
+
+const { data: fullEvent } = await getEvent(eventId, { include: includes })
+// fullEvent.data[] now contains all available data objects
+```
+
+### Event Type to Data Schema Mapping
+
+The toolkit provides a static mapping and utility functions for dynamically building the `include` parameter:
+
+```typescript
+import {
+  getIncludeParameterForEventTypes,
+  getDataSchemasForEventType,
+  eventTypeHasDataSchemas,
+  EVENT_TYPE_DATA_SCHEMAS
+} from 'een-api-toolkit'
+
+// Get include values for selected event types (with data. prefix)
+const includeValues = getIncludeParameterForEventTypes([
+  'een.personDetectionEvent.v1',
+  'een.vehicleDetectionEvent.v1'
+])
+// ['data.een.objectDetection.v1', 'data.een.personAttributes.v1', ...]
+
+// Get schemas for a specific event type (without data. prefix)
+const schemas = getDataSchemasForEventType('een.personDetectionEvent.v1')
+// ['een.objectDetection.v1', 'een.personAttributes.v1', ...]
+
+// Check if event type has data schemas
+if (eventTypeHasDataSchemas('een.personDetectionEvent.v1')) {
+  // Include data schemas in the API call
+}
+
+// Access the complete mapping
+const mapping = EVENT_TYPE_DATA_SCHEMAS['een.motionDetectionEvent.v1']
+```
+
+See `docs/ai-reference/AI-EVENT-DATA-SCHEMAS.md` for the complete event type to data schema reference.
 
 ### EventMetric Interface
 ```typescript
@@ -118,10 +190,10 @@ async function fetchEvents(cameraId: string) {
 
   const result = await listEvents({
     actor: `camera:${cameraId}`,
-    startTimestamp: formatTimestamp(hourAgo),
-    endTimestamp: formatTimestamp(now),
     type__in: ['een.motionDetectionEvent.v1', 'een.objectDetectionEvent.v1'],
-    include: ['data.overlays'],  // Include bounding box SVGs
+    startTimestamp__gte: formatTimestamp(hourAgo.toISOString()),
+    startTimestamp__lte: formatTimestamp(now.toISOString()),
+    include: ['data.een.fullFrameImageUrl.v1'],  // Include image URLs
     pageSize: 50
   })
 
@@ -250,6 +322,19 @@ async function fetchAlerts() {
 }
 ```
 
+### Alert Priority
+Alert priority is an integer value ranging from **0 to 10**:
+- `0` = Lowest priority
+- `10` = Highest priority
+
+Use priority to filter or sort alerts by importance:
+```typescript
+const result = await listAlerts({
+  priority__gte: 7,  // High priority alerts only
+  status__in: ['active']
+})
+```
+
 ### listNotifications()
 Get user notifications:
 ```typescript
@@ -269,12 +354,20 @@ async function fetchNotifications() {
 
 ## SSE (Server-Sent Events) for Real-Time Updates
 
+### SSE Subscription Behavior
+
+**Important: TTL is read-only and server-determined**
+- SSE subscriptions have a **15-minute TTL** (900 seconds) set by the server
+- The `timeToLiveSeconds` value **cannot be customized** when creating a subscription
+- The `subscriptionConfig` (including `lifeCycle` and `timeToLiveSeconds`) is returned in the API response but is not a configurable input
+- SSE URLs are **single-use**: once disconnected, you must create a new subscription
+
 ### SSE Lifecycle
 
-1. **Create Subscription** - Get a subscription with SSE URL
+1. **Create Subscription** - Get a subscription with SSE URL (server sets 15-min TTL)
 2. **Connect to Stream** - Open EventSource connection
 3. **Handle Events** - Process events as they arrive
-4. **Cleanup** - Delete subscription when done
+4. **Cleanup** - Delete subscription when done (or it auto-expires after 15 min of inactivity)
 
 ### createEventSubscription()
 ```typescript
@@ -337,23 +430,22 @@ onUnmounted(async () => {
 
 Use `getRecordedImage()` to fetch a thumbnail image for an event:
 ```typescript
-import { getRecordedImage, type Event } from 'een-api-toolkit'
+import { getRecordedImage, formatTimestamp, type Event } from 'een-api-toolkit'
 
 const eventImages = ref<Map<string, string>>(new Map())
 
 async function fetchEventThumbnail(event: Event) {
-  // Extract camera ID from actor (format: "camera:{cameraId}")
-  const cameraId = event.actor.replace('camera:', '')
+  // Extract device ID from actorId
+  const deviceId = event.actorId
 
   const result = await getRecordedImage({
-    cameraId,
-    timestamp: event.timestamp,
-    width: 120,  // Thumbnail size
-    height: 80
+    deviceId,
+    timestamp: formatTimestamp(event.startTimestamp),
+    type: 'preview'
   })
 
-  if (result.data?.dataUrl) {
-    eventImages.value.set(event.id, result.data.dataUrl)
+  if (result.data?.imageData) {
+    eventImages.value.set(event.id, result.data.imageData)
   }
 }
 

--- a/.claude/agents/een-media-agent.md.backup
+++ b/.claude/agents/een-media-agent.md.backup
@@ -1,0 +1,335 @@
+---
+name: een-media-agent
+description: |
+  Use this agent when implementing live video, camera previews, recorded
+  images, HLS playback, or any media-related features with the een-api-toolkit.
+  This includes troubleshooting video display issues.
+model: inherit
+color: red
+---
+
+You are an expert in media and video streaming with the een-api-toolkit.
+
+## Examples
+
+<example>
+Context: User wants to display camera thumbnails.
+user: "How do I show live preview images from my cameras?"
+assistant: "I'll use the een-media-agent to help implement camera previews using getLiveImage() or multipartUrl streams."
+<Task tool call to launch een-media-agent>
+</example>
+
+<example>
+Context: User wants to play live video.
+user: "How do I show full-quality live video from a camera?"
+assistant: "I'll use the een-media-agent to help integrate the Live Video SDK for streaming."
+<Task tool call to launch een-media-agent>
+</example>
+
+<example>
+Context: User has video display issues.
+user: "My HLS video player isn't working"
+assistant: "I'll use the een-media-agent to diagnose the HLS configuration and authentication setup."
+<Task tool call to launch een-media-agent>
+</example>
+
+## Context Files
+- docs/AI-CONTEXT.md (overview)
+- docs/ai-reference/AI-AUTH.md (auth is required)
+- docs/ai-reference/AI-DEVICES.md (camera context)
+- docs/ai-reference/AI-MEDIA.md (primary reference)
+
+## Reference Examples
+- examples/vue-media/ (LiveCamera, RecordedImage, HLS playback)
+- examples/vue-feeds/ (Preview and Main streams)
+
+## Your Capabilities
+1. Display live camera previews with getLiveImage()
+2. Set up MJPEG streams with multipartUrl
+3. Implement full-resolution video with Live Video SDK
+4. Play recorded video via HLS
+5. Navigate recorded images with getRecordedImage()
+6. Initialize media sessions for cookie-based auth
+
+## Critical Rules
+
+**NEVER:**
+- Construct API URLs directly for `<img>` tags
+- Modify multipartUrl with query parameters
+- Use multipartUrl without initMediaSession() first
+- Assume timestamps are ISO 8601 (they use +00:00 format)
+- Pass ANY arguments to LivePlayer constructor - it MUST be called as `new LivePlayer()` with no arguments
+
+**ALWAYS:**
+- Use getLiveImage() for simple thumbnails
+- Use initMediaSession() before multipartUrl
+- Use formatTimestamp() for EEN API timestamps
+- Check authentication before media operations
+- Pass config to LivePlayer's `start()` method, NOT the constructor
+
+## Choosing the Right Preview Method
+
+| Use Case | Method | Why |
+|----------|--------|-----|
+| Grid of 20+ cameras | `getLiveImage()` | Lower bandwidth, manual refresh |
+| Auto-updating preview | `multipartUrl` + `initMediaSession()` | Automatic updates, higher bandwidth |
+| Full-quality live video | Live Video SDK | Full resolution, lowest latency |
+| Recorded video playback | HLS via `listMedia()` | Seek capability, standard player |
+
+**CRITICAL: Main feeds do NOT support multipartUrl**
+
+The EEN API only returns `multipartUrl` for **preview feeds** (`type: 'preview'`), not main feeds (`type: 'main'`).
+
+- **Preview feeds** → Use `multipartUrl` (MJPEG in `<img>` element)
+- **Main feeds** → Use **Live Video SDK** (full HD in `<video>` element)
+
+If you need HD quality video, you MUST use the Live Video SDK. Do not attempt to use `multipartUrl` with main feeds - it won't work.
+
+## Key Functions
+
+### getLiveImage(cameraId)
+Get a live preview image (returns data URL):
+```typescript
+import { getLiveImage, type LiveImageResult } from 'een-api-toolkit'
+
+const imageUrl = ref<string>('')
+
+async function fetchPreview(cameraId: string) {
+  const result = await getLiveImage({
+    cameraId,
+    width: 320,
+    height: 240,
+    type: 'jpeg'
+  })
+
+  if (result.data) {
+    imageUrl.value = result.data.dataUrl  // Use directly in <img src>
+  }
+}
+```
+
+### initMediaSession()
+Initialize media session for cookie-based auth:
+```typescript
+import { initMediaSession, type MediaSessionResult } from 'een-api-toolkit'
+
+const mediaSession = ref<MediaSessionResult | null>(null)
+
+async function setupMediaSession() {
+  const result = await initMediaSession()
+
+  if (result.data) {
+    mediaSession.value = result.data
+    // Now multipartUrl will work with auth cookies
+  }
+}
+```
+
+### Using multipartUrl (MJPEG Stream)
+
+**Feed Types:**
+| Feed Type | Use Case | Quality |
+|-----------|----------|---------|
+| `preview` | Camera sidebar thumbnails, grids | Lower bandwidth, smaller resolution |
+| `main` | Primary video player, HD viewing | Full quality, higher bandwidth |
+
+```typescript
+// MUST call initMediaSession() first!
+import { listFeeds, initMediaSession } from 'een-api-toolkit'
+
+onMounted(async () => {
+  // Step 1: Initialize media session
+  await initMediaSession()
+
+  // Step 2: Get feeds - specify type for desired quality
+  const result = await listFeeds({
+    deviceId: props.camera.id,
+    type: 'preview',           // 'preview' for thumbnails, 'main' for HD
+    include: ['multipartUrl']  // Request multipartUrl to be included
+  })
+
+  if (result.data) {
+    const feed = result.data.results?.find(f => f.multipartUrl)
+    if (feed?.multipartUrl) {
+      // Step 3: Use multipartUrl directly - DO NOT modify it
+      previewImageUrl.value = feed.multipartUrl
+    }
+  }
+})
+```
+
+### getRecordedImage()
+Get an image at a specific timestamp:
+```typescript
+import { getRecordedImage, formatTimestamp } from 'een-api-toolkit'
+
+async function fetchRecordedFrame(cameraId: string, date: Date) {
+  const result = await getRecordedImage({
+    cameraId,
+    timestamp: formatTimestamp(date),  // MUST use formatTimestamp()
+    width: 640,
+    height: 480
+  })
+
+  if (result.data) {
+    imageUrl.value = result.data.dataUrl
+  }
+}
+```
+
+### listMedia()
+List recorded media intervals:
+```typescript
+import { listMedia, formatTimestamp, type ListMediaParams } from 'een-api-toolkit'
+
+async function fetchRecordings(cameraId: string, startDate: Date, endDate: Date) {
+  const result = await listMedia({
+    cameraId,
+    startTimestamp: formatTimestamp(startDate),
+    endTimestamp: formatTimestamp(endDate),
+    type: 'video'
+  })
+
+  if (result.data) {
+    // result.data.results contains MediaInterval objects
+    // Each has startTimestamp, endTimestamp, and URL for HLS playback
+  }
+}
+```
+
+### formatTimestamp()
+Convert JavaScript Date to EEN API format:
+```typescript
+import { formatTimestamp } from 'een-api-toolkit'
+
+const date = new Date()
+const eenTimestamp = formatTimestamp(date)
+// Returns: "2024-01-15T10:30:00.000+00:00"
+```
+
+## HLS Playback Setup
+
+```typescript
+import Hls from 'hls.js'
+import { useAuthStore } from 'een-api-toolkit'
+
+function setupHlsPlayer(videoElement: HTMLVideoElement, hlsUrl: string) {
+  const authStore = useAuthStore()
+
+  const hls = new Hls({
+    xhrSetup: (xhr) => {
+      xhr.setRequestHeader('Authorization', `Bearer ${authStore.token}`)
+    }
+  })
+
+  hls.loadSource(hlsUrl)
+  hls.attachMedia(videoElement)
+
+  hls.on(Hls.Events.ERROR, (event, data) => {
+    if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+      console.error('HLS network error:', data.details)
+    }
+  })
+}
+```
+
+## Live Video SDK Integration
+
+For full-quality live video, use the EEN Live Video Web SDK:
+
+```typescript
+// Install: npm install @een/live-video-web-sdk
+
+import LivePlayer from '@een/live-video-web-sdk'
+import { useAuthStore } from 'een-api-toolkit'
+
+// Store player instance for cleanup
+let livePlayer: LivePlayer | null = null
+
+async function setupLiveVideo(videoElement: HTMLVideoElement, cameraId: string) {
+  const authStore = useAuthStore()
+
+  // CRITICAL: Create LivePlayer WITHOUT arguments
+  livePlayer = new LivePlayer()
+
+  // CRITICAL: Pass config to start(), NOT to constructor
+  await livePlayer.start({
+    videoElement,      // HTML video element (required)
+    cameraId,          // Camera device ID (required)
+    baseUrl: authStore.baseUrl,  // EEN API base URL (required)
+    jwt: authStore.token         // Auth token (required)
+  })
+
+  return livePlayer
+}
+
+// Clean up when done
+function stopLiveVideo() {
+  if (livePlayer) {
+    livePlayer.stop()
+    livePlayer = null
+  }
+}
+```
+
+### IMPORTANT: LivePlayer Usage Pattern
+
+**CORRECT pattern:**
+```typescript
+const player = new LivePlayer()        // No arguments to constructor
+await player.start(config)             // Config passed to start()
+```
+
+**WRONG pattern (will cause "Video Stream is done" errors):**
+```typescript
+const player = new LivePlayer(config)  // DON'T pass config here
+await player.start()                   // This won't work correctly
+```
+
+### IMPORTANT: Video Element Must Be in DOM
+
+The video element MUST be rendered in the DOM before calling `player.start()`.
+
+**Problem:** Using `v-if` to conditionally show the video element means it doesn't exist during loading:
+```vue
+<!-- WRONG: Video element doesn't exist when loading=true -->
+<div v-if="loading">Loading...</div>
+<video v-else ref="videoRef" />  <!-- Not in DOM during loading! -->
+```
+
+**Solution:** Always render the video element, use CSS to hide it:
+```vue
+<!-- CORRECT: Video element always exists in DOM -->
+<div v-if="loading" class="loading-overlay">Loading...</div>
+<div class="video-container" :class="{ hidden: loading }">
+  <video ref="videoRef" />  <!-- Always in DOM -->
+</div>
+
+<style>
+.video-container.hidden {
+  visibility: hidden;
+  position: absolute;
+}
+</style>
+```
+
+## Error Handling
+
+| Error Code | Meaning | Action |
+|------------|---------|--------|
+| AUTH_REQUIRED | Not authenticated | Redirect to login |
+| MEDIA_NOT_AVAILABLE | No media for time range | Show "no recording" message |
+| CAMERA_OFFLINE | Camera not streaming | Show offline indicator |
+| NETWORK_ERROR | Connection failed | Check network, retry |
+
+## Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Image not loading | Auth not in cookies | Call initMediaSession() first |
+| Timestamp errors | Wrong format | Use formatTimestamp() |
+| CORS errors | Direct API access | Use toolkit functions, not direct fetch |
+| Black video (HLS) | HLS auth missing | Configure xhrSetup with token |
+| "Video Stream is done" immediately | Config passed to LivePlayer constructor | MUST use `new LivePlayer()` with no args, then `player.start(config)` |
+| "Video element not found" | Video element not in DOM | Ensure video element is rendered (not hidden by v-if) before SDK init |
+| Black video, no errors (LivePlayer) | Video element hidden by v-if | Use CSS visibility/opacity instead of v-if for conditional video display |

--- a/.claude/agents/een-users-agent.md.backup
+++ b/.claude/agents/een-users-agent.md.backup
@@ -1,0 +1,239 @@
+---
+name: een-users-agent
+description: |
+  Use this agent when working with user management: listing users, getting
+  user details, displaying current user profile, or implementing user-related
+  features with the een-api-toolkit.
+model: inherit
+color: cyan
+---
+
+You are an expert in user management with the een-api-toolkit.
+
+## Examples
+
+<example>
+Context: User wants to display a list of users.
+user: "How do I show a paginated list of users?"
+assistant: "I'll use the een-users-agent to help implement user listing with pagination using getUsers()."
+<Task tool call to launch een-users-agent>
+</example>
+
+<example>
+Context: User wants to show the current user's profile.
+user: "How do I get the logged-in user's information?"
+assistant: "I'll use the een-users-agent to help display the current user profile using getCurrentUser()."
+<Task tool call to launch een-users-agent>
+</example>
+
+<example>
+Context: User has an error fetching user data.
+user: "I'm getting NOT_FOUND when trying to get a user"
+assistant: "I'll use the een-users-agent to diagnose the user lookup issue and implement proper error handling."
+<Task tool call to launch een-users-agent>
+</example>
+
+## Context Files
+- docs/AI-CONTEXT.md (overview)
+- docs/ai-reference/AI-AUTH.md (auth is required)
+- docs/ai-reference/AI-USERS.md (primary reference)
+
+## Reference Example
+- examples/vue-users/ (complete working example)
+
+## Your Capabilities
+1. List and paginate users with getUsers()
+2. Get current user profile with getCurrentUser()
+3. Get specific user details with getUser()
+4. Implement user permission checks
+5. Handle NOT_FOUND errors for missing users
+
+## Key Types
+
+### User Interface
+```typescript
+interface User {
+  id: string
+  firstName?: string
+  lastName?: string
+  email: string
+  isActive?: boolean
+  permissions?: string[]
+  lastLogin?: string
+  // ... additional optional fields
+}
+```
+
+### UserProfile (Current User)
+```typescript
+interface UserProfile {
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+  accountId: string
+  permissions: string[]
+  // ... profile-specific fields
+}
+```
+
+### ListUsersParams
+```typescript
+interface ListUsersParams {
+  pageSize?: number      // Number of results (default: 100)
+  pageToken?: string     // Cursor for next page
+  include?: string[]     // Additional fields to include
+}
+```
+
+## Key Functions
+
+### getCurrentUser()
+Get the authenticated user's profile:
+```typescript
+import { getCurrentUser, type UserProfile } from 'een-api-toolkit'
+
+const profile = ref<UserProfile | null>(null)
+
+onMounted(async () => {
+  const result = await getCurrentUser()
+  if (result.error) {
+    console.error(result.error.message)
+    return
+  }
+  profile.value = result.data
+})
+```
+
+### getUsers()
+List all users with pagination:
+```typescript
+import { getUsers, type User, type ListUsersParams } from 'een-api-toolkit'
+
+const users = ref<User[]>([])
+const nextPageToken = ref<string | undefined>()
+
+async function fetchUsers(params?: ListUsersParams) {
+  const result = await getUsers(params)
+
+  if (result.error) {
+    console.error(result.error.message)
+    return
+  }
+
+  users.value = result.data.results
+  nextPageToken.value = result.data.nextPageToken
+}
+
+// Load more
+async function loadMore() {
+  if (!nextPageToken.value) return
+
+  const result = await getUsers({ pageToken: nextPageToken.value })
+  if (result.data) {
+    users.value.push(...result.data.results)
+    nextPageToken.value = result.data.nextPageToken
+  }
+}
+```
+
+### getUser(id)
+Get a specific user by ID:
+```typescript
+import { getUser, type User } from 'een-api-toolkit'
+
+async function fetchUser(userId: string) {
+  const result = await getUser({ id: userId })
+
+  if (result.error) {
+    if (result.error.code === 'NOT_FOUND') {
+      console.error('User not found')
+    }
+    return null
+  }
+
+  return result.data
+}
+```
+
+## Complete Vue Component Example
+
+```vue
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { getUsers, type User, type EenError, type ListUsersParams } from 'een-api-toolkit'
+
+const users = ref<User[]>([])
+const loading = ref(false)
+const error = ref<EenError | null>(null)
+const nextPageToken = ref<string | undefined>()
+
+const hasNextPage = computed(() => !!nextPageToken.value)
+
+async function fetchUsers(params?: ListUsersParams, append = false) {
+  loading.value = true
+  error.value = null
+
+  const result = await getUsers(params)
+
+  if (result.error) {
+    error.value = result.error
+    if (!append) users.value = []
+    nextPageToken.value = undefined
+  } else {
+    if (append) {
+      users.value = [...users.value, ...result.data.results]
+    } else {
+      users.value = result.data.results
+    }
+    nextPageToken.value = result.data.nextPageToken
+  }
+
+  loading.value = false
+}
+
+onMounted(() => fetchUsers({ pageSize: 10 }))
+</script>
+
+<template>
+  <div class="users">
+    <div v-if="loading && users.length === 0">Loading...</div>
+    <div v-else-if="error">Error: {{ error.message }}</div>
+    <div v-else>
+      <table v-if="users.length > 0">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="user in users" :key="user.id">
+            <td>{{ user.firstName }} {{ user.lastName }}</td>
+            <td>{{ user.email }}</td>
+            <td>{{ user.isActive ? 'Active' : 'Inactive' }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <button v-if="hasNextPage" @click="fetchUsers({ pageToken: nextPageToken }, true)">
+        Load More
+      </button>
+    </div>
+  </div>
+</template>
+```
+
+## Error Handling
+
+| Error Code | Meaning | Action |
+|------------|---------|--------|
+| AUTH_REQUIRED | Not authenticated | Redirect to login |
+| NOT_FOUND | User doesn't exist | Show "user not found" message |
+| API_ERROR | Server error | Show error, allow retry |
+| NETWORK_ERROR | Connection failed | Check network, allow retry |
+
+## Constraints
+- Always check isAuthenticated before calling user APIs
+- Handle pagination properly - don't assume all users fit in one response
+- Use include[] parameter sparingly to reduce payload size

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -257,22 +257,62 @@ function getNotificationActions(notification: Notification): string[] {
   return actions
 }
 
-// Get tooltip text for notification action (includes description if available)
+// Get tooltip text for notification action (title on first line, details on second, notes on third)
 function getNotificationActionTooltip(action: string, notification?: Notification): string {
-  const tooltips: Record<string, string> = {
-    email: 'Email notification',
-    sms: 'SMS notification',
-    push: 'Push notification',
-    gui: 'GUI notification'
+  const titles: Record<string, string> = {
+    email: 'Email Notification',
+    sms: 'SMS Notification',
+    push: 'Push Notification',
+    gui: 'GUI Notification'
   }
-  const baseTooltip = tooltips[action] || 'Notification (unknown type)'
+  const title = titles[action] || `${action.charAt(0).toUpperCase() + action.slice(1)} Notification`
 
-  // Add description on second line if available
-  const description = (notification as unknown as { description?: string })?.description
+  const notifData = notification as unknown as { description?: string; notes?: string | null }
+  const description = notifData?.description
+  const notes = notifData?.notes
+  let tooltip = title
   if (description) {
-    return `${baseTooltip}\n${description}`
+    tooltip += '\n' + description
   }
-  return baseTooltip
+  if (notes) {
+    tooltip += '\n' + notes
+  }
+  return tooltip
+}
+
+// Get tooltip text for action icons (title on first line, name on second, notes on third)
+function getActionTooltip(type: string, name?: string, actionId?: string): string {
+  const titles: Record<string, string> = {
+    zapier: 'Zapier Action',
+    webhook: 'Webhook Action',
+    notification: 'Notification Action'
+  }
+  const title = titles[type] || `${type.charAt(0).toUpperCase() + type.slice(1)} Action`
+
+  let tooltip = title
+  if (name) {
+    tooltip += '\n' + name
+  }
+  // Look up notes from the action definition
+  if (actionId) {
+    const actionDef = alertActionsMap.value.get(actionId)
+    const notes = (actionDef as unknown as { notes?: string | null })?.notes
+    if (notes) {
+      tooltip += '\n' + notes
+    }
+  }
+  return tooltip
+}
+
+// Get tooltip for event alert condition rule (title, name, notes)
+function getRuleTooltip(rule: EventAlertConditionRule): string {
+  let tooltip = 'Event Condition'
+  tooltip += '\n' + (rule.name || 'Unnamed rule')
+  const notes = (rule as unknown as { notes?: string }).notes
+  if (notes) {
+    tooltip += '\n' + notes
+  }
+  return tooltip
 }
 
 // Get actions from alert (e.g., zapier, webhook) - actions is an object with UUIDs as keys
@@ -519,7 +559,7 @@ async function fetchAlerts(append = false) {
     alertType__in: alertTypes,
     pageSize: 100,
     pageToken: append ? alertsNextPageToken.value : undefined,
-    include: ['data', 'actions', 'description'],
+    include: ['data', 'actions', 'dataSchemas', 'description'],
     sort: ['-timestamp']
   })
 
@@ -753,7 +793,7 @@ onUnmounted(() => {
               v-if="alert.eventAlertConditionRule"
               @click="showRuleDetails(alert.eventAlertConditionRule!, $event)"
               class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
-              title="View event alert condition rule"
+              :title="getRuleTooltip(alert.eventAlertConditionRule!)"
             >
               <svg class="w-3.5 h-3.5" :class="isDark ? 'text-purple-400' : 'text-purple-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
@@ -767,7 +807,7 @@ onUnmounted(() => {
                 <button
                   v-if="actionItem.type === 'zapier'"
                   class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
-                  :title="actionItem.name || 'Zapier action'"
+                  :title="getActionTooltip('zapier', actionItem.name, actionItem.id)"
                   @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
                 >
                   <svg class="w-3.5 h-3.5" :class="isDark ? 'text-orange-400' : 'text-orange-500'" viewBox="0 0 24 24" fill="currentColor">
@@ -778,11 +818,22 @@ onUnmounted(() => {
                 <button
                   v-else-if="actionItem.type === 'webhook'"
                   class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
-                  :title="actionItem.name || 'Webhook action'"
+                  :title="getActionTooltip('webhook', actionItem.name, actionItem.id)"
                   @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
                 >
                   <svg class="w-3.5 h-3.5" :class="isDark ? 'text-indigo-400' : 'text-indigo-500'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                  </svg>
+                </button>
+                <!-- Notification icon (megaphone) -->
+                <button
+                  v-else-if="actionItem.type === 'notification'"
+                  class="flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
+                  :title="getActionTooltip('notification', actionItem.name, actionItem.id)"
+                  @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
+                >
+                  <svg class="w-3.5 h-3.5" :class="isDark ? 'text-teal-400' : 'text-teal-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
                   </svg>
                 </button>
                 <!-- Unknown action type -->
@@ -790,7 +841,7 @@ onUnmounted(() => {
                   v-else
                   class="text-xs flex-shrink-0 p-0.5 rounded hover:bg-black/10 transition-colors"
                   :class="isDark ? 'text-gray-400' : 'text-gray-500'"
-                  :title="actionItem.name || actionItem.type"
+                  :title="getActionTooltip(actionItem.type, actionItem.name, actionItem.id)"
                   @click="showActionDetails(actionItem.id, actionItem.execution, $event)"
                 >
                   {{ actionItem.type }}
@@ -799,6 +850,7 @@ onUnmounted(() => {
             </template>
             <!-- 3. Notification Icons (for all notifications associated with this alert) -->
             <template v-if="alert.notifications && alert.notifications.length > 0">
+              <span class="text-xs font-bold" :class="isDark ? 'text-gray-400' : 'text-gray-500'">(</span>
               <template v-for="notification in alert.notifications" :key="notification.id">
                 <button
                   v-for="action in getNotificationActions(notification)"
@@ -831,6 +883,7 @@ onUnmounted(() => {
                   </svg>
                 </button>
               </template>
+              <span class="text-xs font-bold" :class="isDark ? 'text-gray-400' : 'text-gray-500'">)</span>
             </template>
           </div>
           <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-500' : 'text-gray-400'">

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -220,6 +220,12 @@ const eventDataSchemas = computed(() => {
   return getDataSchemasForEventType(eventType)
 })
 
+// Include parameter values used in the alert API call
+const alertIncludeValues = computed(() => {
+  if (!props.playbackEventObject || !props.isAlertSource) return []
+  return ['data', 'actions', 'dataSchemas', 'description']
+})
+
 // Calculate event duration from startTimestamp and endTimestamp
 const eventDuration = computed(() => {
   if (!props.playbackEventObject) return null
@@ -938,6 +944,19 @@ onUnmounted(() => {
                 class="px-2 py-0.5 text-xs rounded-full font-mono"
                 :class="isDark ? 'bg-blue-900/50 text-blue-300' : 'bg-blue-100 text-blue-700'"
               >{{ schema }}</span>
+            </div>
+          </div>
+
+          <!-- Include values (for alerts only) -->
+          <div v-if="alertIncludeValues.length > 0" class="px-4 pt-3 pb-1">
+            <div class="text-xs mb-1" :class="isDark ? 'text-gray-400' : 'text-gray-500'">Include Parameter for <span class="font-bold" :class="isDark ? 'text-gray-200' : 'text-gray-700'">{{ playbackEventType }}</span> Alert:</div>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="value in alertIncludeValues"
+                :key="value"
+                class="px-2 py-0.5 text-xs rounded-full font-mono"
+                :class="isDark ? 'bg-amber-900/50 text-amber-300' : 'bg-amber-100 text-amber-700'"
+              >{{ value }}</span>
             </div>
           </div>
 

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
-import { useAuthStore, getEvent } from 'een-api-toolkit'
+import { useAuthStore, getEvent, getDataSchemasForEventType } from 'een-api-toolkit'
 import type { Camera, CameraStatus } from 'een-api-toolkit'
 import LivePlayer from '@een/live-video-web-sdk'
 import { useHlsPlayer } from '@/composables/useHlsPlayer'
@@ -211,6 +211,14 @@ const formattedPlaybackTimestamp = computed(() => {
 
 // Current data type for modal title
 const currentDataType = computed(() => props.isAlertSource ? 'Alert' : 'Event')
+
+// Data schemas available for the current event type
+const eventDataSchemas = computed(() => {
+  if (!props.playbackEventObject || props.isAlertSource) return []
+  const eventType = props.playbackEventObject.type as string | undefined
+  if (!eventType) return []
+  return getDataSchemasForEventType(eventType)
+})
 
 // Calculate event duration from startTimestamp and endTimestamp
 const eventDuration = computed(() => {
@@ -917,6 +925,19 @@ onUnmounted(() => {
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
+            </div>
+          </div>
+
+          <!-- Data Schemas (for events only) -->
+          <div v-if="eventDataSchemas.length > 0" class="px-4 pt-3 pb-1">
+            <div class="text-xs mb-1" :class="isDark ? 'text-gray-400' : 'text-gray-500'">Available Data Schemas for <span class="font-bold" :class="isDark ? 'text-gray-200' : 'text-gray-700'">{{ playbackEventType }}</span> Event:</div>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="schema in eventDataSchemas"
+                :key="schema"
+                class="px-2 py-0.5 text-xs rounded-full font-mono"
+                :class="isDark ? 'bg-blue-900/50 text-blue-300' : 'bg-blue-100 text-blue-700'"
+              >{{ schema }}</span>
             </div>
           </div>
 

--- a/src/composables/useImageCache.ts
+++ b/src/composables/useImageCache.ts
@@ -52,7 +52,8 @@ class LRUImageCache {
 const imageCache = new LRUImageCache(250)
 
 // Track images currently being loaded to prevent duplicate requests
-const loadingImages = new Set<string>()
+// Maps loadKey to a promise so other callers can await the same request
+const loadingImages = new Map<string, Promise<string | null>>()
 
 export function useImageCache() {
   // Local reactive state for component-specific image mapping
@@ -72,33 +73,43 @@ export function useImageCache() {
       return cachedImage
     }
 
-    // Check if already loading
+    // Check if already loading - await the in-flight request then use cache
     const loadKey = `${cameraId}:${timestamp}`
-    if (loadingImages.has(loadKey)) {
+    const existingRequest = loadingImages.get(loadKey)
+    if (existingRequest) {
+      await existingRequest
+      const cachedAfterWait = imageCache.get(cameraId, timestamp)
+      if (cachedAfterWait) {
+        images.value[eventId] = cachedAfterWait
+        return cachedAfterWait
+      }
       return null
     }
 
-    loadingImages.add(loadKey)
+    const request = (async (): Promise<string | null> => {
+      try {
+        const result = await getRecordedImage({
+          deviceId: cameraId,
+          type: 'preview',
+          timestamp__gte: timestamp,
+          targetWidth: 384
+        })
 
-    try {
-      const result = await getRecordedImage({
-        deviceId: cameraId,
-        type: 'preview',
-        timestamp__gte: timestamp,
-        targetWidth: 384
-      })
-
-      if (!result.error && result.data) {
-        // Store in LRU cache and local state
-        imageCache.set(cameraId, timestamp, result.data.imageData)
-        images.value[eventId] = result.data.imageData
-        return result.data.imageData
+        if (!result.error && result.data) {
+          // Store in LRU cache and local state
+          imageCache.set(cameraId, timestamp, result.data.imageData)
+          images.value[eventId] = result.data.imageData
+          return result.data.imageData
+        }
+      } finally {
+        loadingImages.delete(loadKey)
       }
-    } finally {
-      loadingImages.delete(loadKey)
-    }
 
-    return null
+      return null
+    })()
+
+    loadingImages.set(loadKey, request)
+    return request
   }
 
   function getImage(eventId: string): string | null {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -76,6 +76,20 @@ router.beforeEach((to, _from, next) => {
   // Handle URL parameters
   // Store them in sessionStorage so they persist through the OAuth flow but not across sessions
   if (to.path === '/') {
+    // When navigating with no URL parameters, clear all stored URL parameters
+    if (Object.keys(to.query).length === 0) {
+      sessionStorage.removeItem('een_url_camera_ids')
+      sessionStorage.removeItem('een_url_selected')
+      sessionStorage.removeItem('een_url_events')
+      sessionStorage.removeItem('een_url_ed')
+      sessionStorage.removeItem('een_url_ad')
+      sessionStorage.removeItem('een_url_er')
+      sessionStorage.removeItem('een_url_ar')
+      sessionStorage.removeItem('een_url_live')
+      sessionStorage.removeItem('een_url_filter')
+      sessionStorage.removeItem('een_url_dark')
+    }
+
     if (to.query.id) {
       // Store camera IDs from URL
       sessionStorage.setItem('een_url_camera_ids', to.query.id as string)


### PR DESCRIPTION
## Summary
- Display alert API include parameter values (amber badges) in the alert data modal, mirroring how event data schemas are shown
- Add `dataSchemas` to the alert include parameter for complete data retrieval
- Add notification action icon (teal megaphone) with notification method icons grouped in parentheses
- Add multi-line tooltips with category titles and optional notes for all alert card icons
- Fix race condition in image cache where alerts with identical timestamps only showed one thumbnail
- Clear sessionStorage URL parameters when navigating to bare URL (no query params)
- Add port 3333 cleanup to dev script
- Update agent documentation with alert include parameter details

## Test plan
- [x] All 20 E2E tests pass
- [ ] Verify alert modal shows amber include parameter badges when clicking alert info button
- [ ] Verify notification icon (megaphone) appears for notification actions with method icons in parentheses
- [ ] Verify tooltips show category title on first line, name on second, notes on third (when present)
- [ ] Verify two alerts with same timestamp both show thumbnails
- [ ] Verify navigating to bare URL clears previous session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)