### PR TITLE
Add camera data modal and Google Maps integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",
-        "een-api-toolkit": "^0.3.35",
+        "een-api-toolkit": "^0.3.63",
         "hls.js": "^1.6.15",
         "pinia": "^3.0.4",
         "typescript": "^5.9.3",
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/een-api-toolkit": {
-      "version": "0.3.55",
-      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.55.tgz",
-      "integrity": "sha512-qbfgUZUo/sVyjAX2YcoE3Yt6n0mRK4knjniQm3FrHYPAOOFcijVAeQ8cdthE3DqCncv9Bggrxc+vQmEf67F/oQ==",
+      "version": "0.3.63",
+      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.63.tgz",
+      "integrity": "sha512-HefaeTUDamPZjR8CxQyTj9Wg/FIN/bzQMQLVc253or9KCVa11MYs3k0wXc501HFWqz6ZxVM9wjDvf0Pngcf4gg==",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@een/live-video-web-sdk": "^1.10.2",
     "@vitejs/plugin-vue": "^6.0.3",
-    "een-api-toolkit": "^0.3.35",
+    "een-api-toolkit": "^0.3.63",
     "hls.js": "^1.6.15",
     "pinia": "^3.0.4",
     "typescript": "^5.9.3",

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -106,7 +106,7 @@ async function fetchCameras(append = false) {
 
   const params: ListCamerasParams = {
     pageSize: 100, // Fetch all cameras for local pagination
-    include: ['status', 'deviceInfo']
+    include: ['status', 'deviceInfo', 'devicePosition', 'deviceAddress']
   }
 
   const result = await getCameras(params)

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
-import { useAuthStore, getEvent, getCamera, getDataSchemasForEventType } from 'een-api-toolkit'
+import { useAuthStore, getEvent, getCamera, getCameraSettings, getBridge, getDataSchemasForEventType } from 'een-api-toolkit'
 import type { Camera, CameraStatus } from 'een-api-toolkit'
 import LivePlayer from '@een/live-video-web-sdk'
 import { useHlsPlayer } from '@/composables/useHlsPlayer'
@@ -87,6 +87,37 @@ const isWithinEventTimeRange = computed(() => {
 const showEventDataModal = ref(false)
 const copiedToClipboard = ref(false)
 
+// Camera data modal state
+const showCameraDataModal = ref(false)
+const cameraDataResponse = ref<Record<string, unknown> | null>(null)
+const cameraDataLoading = ref(false)
+const cameraDataCopied = ref(false)
+
+// Camera modal view state
+const cameraModalView = ref<'details' | 'settings' | 'bridge'>('details')
+const cameraSettingsResponse = ref<Record<string, unknown> | null>(null)
+const cameraSettingsLoading = ref(false)
+const bridgeDataResponse = ref<Record<string, unknown> | null>(null)
+const bridgeDataLoading = ref(false)
+
+// All valid include values for getCameraSettings
+const CAMERA_SETTINGS_INCLUDE_VALUES = ['schema', 'proposedValues'] as const
+
+// All valid include values for getBridge
+const BRIDGE_INCLUDE_VALUES = [
+  'status', 'locationSummary', 'deviceAddress', 'timeZone',
+  'notes', 'tags', 'devicePosition', 'networkInfo', 'deviceInfo',
+  'effectivePermissions', 'resourceStatusCounts', 'resourceCounts'
+]
+
+// All valid include values for getCamera
+const CAMERA_INCLUDE_VALUES = [
+  'bridge', 'account', 'status', 'locationSummary', 'deviceAddress', 'timeZone',
+  'notes', 'tags', 'devicePosition', 'networkInfo', 'deviceInfo', 'effectivePermissions',
+  'firmware', 'shareDetails', 'visibleByBridges', 'capabilities', 'analog', 'packages',
+  'dewarpConfig', 'adminCredentials', 'publicSafetySharing', 'enabledAnalytics'
+]
+
 // Video export state
 const { isActive: exportIsActive, startExport } = useVideoExport()
 const exportError = ref<string | null>(null)
@@ -95,6 +126,7 @@ const exportError = ref<string | null>(null)
 function handleEscKey(event: KeyboardEvent) {
   if (event.key === 'Escape') {
     showEventDataModal.value = false
+    showCameraDataModal.value = false
   }
 }
 
@@ -105,7 +137,7 @@ function handlePlaybackKeys(event: KeyboardEvent) {
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
 
   // Ignore when modal is open
-  if (showEventDataModal.value) return
+  if (showEventDataModal.value || showCameraDataModal.value) return
 
   // Only active in recorded mode with a loaded video
   if (isLiveMode.value || !hlsPlayer.videoUrl.value) return
@@ -142,8 +174,8 @@ function handlePlaybackKeys(event: KeyboardEvent) {
 }
 
 // Watch modal state to add/remove ESC key listener
-watch(showEventDataModal, (isOpen) => {
-  if (isOpen) {
+watch([showEventDataModal, showCameraDataModal], ([eventOpen, cameraOpen]) => {
+  if (eventOpen || cameraOpen) {
     document.addEventListener('keydown', handleEscKey)
   } else {
     document.removeEventListener('keydown', handleEscKey)
@@ -163,6 +195,130 @@ async function copyDataToClipboard() {
     console.error('Failed to copy to clipboard:', err)
   }
 }
+
+// Fetch camera details with all include values
+async function fetchCameraDetails() {
+  cameraDataLoading.value = true
+  cameraDataResponse.value = null
+  cameraModalView.value = 'details'
+  cameraDataCopied.value = false
+  showCameraDataModal.value = true
+  try {
+    const { data, error: apiError } = await getCamera(props.camera.id, { include: CAMERA_INCLUDE_VALUES })
+    if (apiError) {
+      cameraDataResponse.value = { error: apiError.message || 'Failed to fetch camera details' }
+    } else {
+      cameraDataResponse.value = data as unknown as Record<string, unknown>
+    }
+  } catch (err) {
+    console.error('Failed to fetch camera details:', err)
+    cameraDataResponse.value = { error: 'Failed to fetch camera details', details: String(err) }
+  } finally {
+    cameraDataLoading.value = false
+  }
+}
+
+// Copy camera data to clipboard (details or settings, whichever is active)
+async function copyCameraDataToClipboard() {
+  const data = activeCameraModalData.value
+  if (!data) return
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(data, null, 2))
+    cameraDataCopied.value = true
+    setTimeout(() => {
+      cameraDataCopied.value = false
+    }, 2000)
+  } catch (err) {
+    console.error('Failed to copy to clipboard:', err)
+  }
+}
+
+// Fetch camera settings with all include values
+async function fetchCameraSettings() {
+  cameraSettingsLoading.value = true
+  cameraSettingsResponse.value = null
+  cameraModalView.value = 'settings'
+  cameraDataCopied.value = false
+  try {
+    const { data, error: apiError } = await getCameraSettings(props.camera.id, { include: [...CAMERA_SETTINGS_INCLUDE_VALUES] })
+    if (apiError) {
+      cameraSettingsResponse.value = { error: apiError.message || 'Failed to fetch camera settings' }
+    } else {
+      cameraSettingsResponse.value = data as unknown as Record<string, unknown>
+    }
+  } catch (err) {
+    console.error('Failed to fetch camera settings:', err)
+    cameraSettingsResponse.value = { error: 'Failed to fetch camera settings', details: String(err) }
+  } finally {
+    cameraSettingsLoading.value = false
+  }
+}
+
+// Fetch bridge details with all include values
+async function fetchBridgeDetails() {
+  if (!props.camera.bridgeId) {
+    bridgeDataResponse.value = { error: 'No bridge associated with this camera' }
+    cameraModalView.value = 'bridge'
+    cameraDataCopied.value = false
+    return
+  }
+  bridgeDataLoading.value = true
+  bridgeDataResponse.value = null
+  cameraModalView.value = 'bridge'
+  cameraDataCopied.value = false
+  try {
+    const { data, error: apiError } = await getBridge(props.camera.bridgeId, { include: BRIDGE_INCLUDE_VALUES })
+    if (apiError) {
+      bridgeDataResponse.value = { error: apiError.message || 'Failed to fetch bridge details' }
+    } else {
+      bridgeDataResponse.value = data as unknown as Record<string, unknown>
+    }
+  } catch (err) {
+    console.error('Failed to fetch bridge details:', err)
+    bridgeDataResponse.value = { error: 'Failed to fetch bridge details', details: String(err) }
+  } finally {
+    bridgeDataLoading.value = false
+  }
+}
+
+// Switch camera modal view (no fetch needed for details since data is already loaded)
+function switchCameraModalView(view: 'details' | 'settings' | 'bridge') {
+  cameraDataCopied.value = false
+  if (view === 'details') {
+    cameraModalView.value = 'details'
+  } else if (view === 'settings') {
+    fetchCameraSettings()
+  } else {
+    fetchBridgeDetails()
+  }
+}
+
+// Active modal data for copy (depends on current view)
+const activeCameraModalData = computed(() => {
+  if (cameraModalView.value === 'settings') return cameraSettingsResponse.value
+  if (cameraModalView.value === 'bridge') return bridgeDataResponse.value
+  return cameraDataResponse.value
+})
+
+const activeCameraModalLoading = computed(() => {
+  if (cameraModalView.value === 'settings') return cameraSettingsLoading.value
+  if (cameraModalView.value === 'bridge') return bridgeDataLoading.value
+  return cameraDataLoading.value
+})
+
+// Active include values for the current view
+const activeCameraModalIncludeValues = computed(() => {
+  if (cameraModalView.value === 'settings') return [...CAMERA_SETTINGS_INCLUDE_VALUES]
+  if (cameraModalView.value === 'bridge') return BRIDGE_INCLUDE_VALUES
+  return CAMERA_INCLUDE_VALUES
+})
+
+// Modal title based on current view
+const cameraModalTitle = computed(() => {
+  if (cameraModalView.value === 'settings') return 'Camera Settings'
+  if (cameraModalView.value === 'bridge') return 'Bridge Data'
+  return 'Camera Data'
+})
 
 // Handle video download - exports the currently playing video clip
 async function handleDownloadClick(e: Event) {
@@ -220,6 +376,26 @@ function isCameraOnline(status?: CameraStatus | { connectionStatus?: CameraStatu
 
 // Computed status values
 const statusString = computed(() => getStatusString(props.camera.status))
+
+// Google Maps URL from camera devicePosition
+const googleMapsUrl = computed(() => {
+  const pos = props.camera.devicePosition
+  if (pos?.latitude != null && pos?.longitude != null) {
+    return `https://www.google.com/maps/search/?api=1&query=${pos.latitude},${pos.longitude}`
+  }
+  return null
+})
+
+// Tooltip for Google Maps icon
+const googleMapsTooltip = computed(() => {
+  const cam = props.camera as unknown as Record<string, unknown>
+  const addr = cam.deviceAddress as { name?: string; address?: string } | undefined
+  const parts: string[] = ['View on Google Maps']
+  if (addr?.name) parts.push(addr.name)
+  if (addr?.address) parts.push(addr.address)
+  return parts.join('\n')
+})
+
 const isOnline = computed(() => isCameraOnline(props.camera.status))
 
 // Status badge styling
@@ -814,12 +990,36 @@ onUnmounted(() => {
       class="w-80 flex-shrink-0 rounded-lg p-4 overflow-y-auto border"
       :class="isDark ? 'bg-gray-900 border-gray-700' : 'bg-white border-gray-200'"
     >
-      <h3 :class="isDark ? 'text-white' : 'text-gray-800'" class="font-semibold text-lg mb-4">Camera Information</h3>
+      <div class="flex items-center justify-between mb-4">
+        <h3 :class="isDark ? 'text-white' : 'text-gray-800'" class="font-semibold text-lg">Camera Information</h3>
+        <button
+          @click="fetchCameraDetails"
+          class="w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold border transition-colors focus:outline-none"
+          :class="isDark ? 'border-teal-400 text-teal-400 hover:bg-teal-400 hover:text-gray-900' : 'border-teal-600 text-teal-600 hover:bg-teal-600 hover:text-white'"
+          title="View full camera data"
+        >
+          i
+        </button>
+      </div>
 
       <div class="space-y-4">
         <!-- Camera Name -->
-        <div>
+        <div class="flex items-center justify-between gap-2">
           <p :class="isDark ? 'text-white' : 'text-gray-800'" class="text-sm font-medium">{{ camera.name }}</p>
+          <a
+            v-if="googleMapsUrl"
+            :href="googleMapsUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex-shrink-0 transition-colors"
+            :class="isDark ? 'text-red-400 hover:text-red-300' : 'text-red-500 hover:text-red-600'"
+            :title="googleMapsTooltip"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </a>
         </div>
 
         <!-- Status -->
@@ -1043,6 +1243,125 @@ onUnmounted(() => {
               class="text-xs font-mono p-4 rounded overflow-auto"
               :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
             >{{ JSON.stringify(playbackEventObject, null, 2) }}</pre>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Camera Data Modal -->
+    <Teleport to="body">
+      <div
+        v-if="showCameraDataModal"
+        class="fixed inset-0 z-50 flex items-center justify-center"
+        @click.self="showCameraDataModal = false"
+      >
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/50" @click="showCameraDataModal = false" />
+
+        <!-- Modal -->
+        <div
+          class="relative rounded-lg shadow-xl max-h-[80vh] flex flex-col"
+          :class="isDark ? 'bg-gray-800' : 'bg-white'"
+          style="width: 80%"
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between p-4 border-b" :class="isDark ? 'border-gray-700' : 'border-gray-200'">
+            <h3 class="text-lg font-semibold" :class="isDark ? 'text-white' : 'text-gray-800'">{{ cameraModalTitle }}</h3>
+            <div class="flex items-center gap-2">
+              <!-- View buttons -->
+              <div class="flex items-center gap-1">
+                <button
+                  @click="switchCameraModalView('details')"
+                  :disabled="activeCameraModalLoading"
+                  class="px-3 py-1 text-xs font-medium rounded transition-colors focus:outline-none"
+                  :class="cameraModalView === 'details'
+                    ? (isDark ? 'bg-blue-600 text-white' : 'bg-blue-600 text-white')
+                    : (isDark ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-gray-200 text-gray-600 hover:bg-gray-300')"
+                >Details</button>
+                <button
+                  @click="switchCameraModalView('settings')"
+                  :disabled="activeCameraModalLoading"
+                  class="px-3 py-1 text-xs font-medium rounded transition-colors focus:outline-none"
+                  :class="cameraModalView === 'settings'
+                    ? (isDark ? 'bg-blue-600 text-white' : 'bg-blue-600 text-white')
+                    : (isDark ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-gray-200 text-gray-600 hover:bg-gray-300')"
+                >Settings</button>
+                <button
+                  @click="switchCameraModalView('bridge')"
+                  :disabled="activeCameraModalLoading"
+                  class="px-3 py-1 text-xs font-medium rounded transition-colors focus:outline-none"
+                  :class="cameraModalView === 'bridge'
+                    ? (isDark ? 'bg-blue-600 text-white' : 'bg-blue-600 text-white')
+                    : (isDark ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-gray-200 text-gray-600 hover:bg-gray-300')"
+                >Bridge</button>
+              </div>
+              <!-- Copy Button -->
+              <button
+                @click="copyCameraDataToClipboard"
+                :disabled="activeCameraModalLoading"
+                class="p-1 rounded transition-colors"
+                :class="[
+                  isDark ? 'hover:bg-gray-700' : 'hover:bg-gray-100',
+                  cameraDataCopied ? (isDark ? 'text-green-400' : 'text-green-600') : (isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-600')
+                ]"
+                :title="cameraDataCopied ? 'Copied!' : 'Copy to clipboard'"
+              >
+                <!-- Checkmark icon when copied -->
+                <svg v-if="cameraDataCopied" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                </svg>
+                <!-- Copy icon -->
+                <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </button>
+              <!-- Close Button -->
+              <button
+                @click="showCameraDataModal = false"
+                class="p-1 rounded transition-colors"
+                :class="[
+                  isDark ? 'hover:bg-gray-700' : 'hover:bg-gray-100',
+                  isDark ? 'text-gray-400 hover:text-white' : 'text-gray-500 hover:text-gray-600'
+                ]"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Include parameter values -->
+          <div class="px-4 pt-3 pb-1">
+            <div class="text-xs mb-1" :class="isDark ? 'text-gray-400' : 'text-gray-500'">Include Parameters:</div>
+            <div class="flex flex-wrap gap-1">
+              <span
+                v-for="value in activeCameraModalIncludeValues"
+                :key="value"
+                class="px-2 py-0.5 text-xs rounded-full font-mono"
+                :class="isDark ? 'bg-teal-900/50 text-teal-300' : 'bg-teal-100 text-teal-700'"
+              >{{ value }}</span>
+            </div>
+          </div>
+
+          <!-- Content -->
+          <div class="p-4 overflow-auto flex-1">
+            <!-- Loading state -->
+            <div v-if="activeCameraModalLoading" class="flex items-center justify-center py-12">
+              <div class="flex items-center gap-3">
+                <svg class="animate-spin w-5 h-5" :class="isDark ? 'text-teal-400' : 'text-teal-600'" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                <span class="text-sm" :class="isDark ? 'text-gray-400' : 'text-gray-500'">Loading camera {{ cameraModalView }}...</span>
+              </div>
+            </div>
+            <!-- JSON response -->
+            <pre
+              v-else-if="activeCameraModalData"
+              class="text-xs font-mono p-4 rounded overflow-auto"
+              :class="isDark ? 'bg-gray-900 text-gray-300' : 'bg-gray-100 text-gray-800'"
+            >{{ JSON.stringify(activeCameraModalData, null, 2) }}</pre>
           </div>
         </div>
       </div>

--- a/tests/cameras.spec.ts
+++ b/tests/cameras.spec.ts
@@ -347,4 +347,119 @@ test.describe('Camera Selection and Video', () => {
 
     console.log('URL camera restoration test completed successfully')
   })
+
+  test('should open Google Maps from map icon and interact with camera data modal', async ({ page, context }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for main video player and camera info panel
+    const mainVideoPlayer = page.locator('.main-video-player')
+    await expect(mainVideoPlayer).toBeVisible({ timeout: TIMEOUTS.VIDEO_LOAD })
+    await expect(mainVideoPlayer.getByText('Camera Information')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Check if map icon is present (camera may or may not have devicePosition)
+    const mapLink = mainVideoPlayer.locator('a[title*="Google Maps"], a[title*="View on"]')
+    const mapVisible = await mapLink.isVisible().catch(() => false)
+
+    if (mapVisible) {
+      // Verify the link points to Google Maps
+      const href = await mapLink.getAttribute('href')
+      expect(href).toContain('google.com/maps')
+      console.log(`Map link found: ${href}`)
+
+      // Verify it opens in a new tab
+      const target = await mapLink.getAttribute('target')
+      expect(target).toBe('_blank')
+
+      // Click and verify new tab opens (then close it)
+      const [newPage] = await Promise.all([
+        context.waitForEvent('page', { timeout: TIMEOUTS.UI_UPDATE }),
+        mapLink.click()
+      ])
+      console.log(`Google Maps opened in new tab: ${newPage.url()}`)
+      await newPage.close()
+    } else {
+      console.log('No map icon visible (camera may lack devicePosition data)')
+    }
+
+    // Click the (i) button next to "Camera Information" to open the camera data modal
+    const infoButton = mainVideoPlayer.locator('button[title="View full camera data"]')
+    await expect(infoButton).toBeVisible()
+    await infoButton.click()
+
+    // Modal should appear with "Camera Data" title
+    const modal = page.locator('.fixed.inset-0.z-50')
+    await expect(modal).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(modal.locator('h3', { hasText: 'Camera Data' })).toBeVisible()
+
+    // Include parameter pills should be visible
+    const pillContainer = modal.locator('.flex.flex-wrap.gap-1')
+    await expect(modal.getByText('Include Parameters:')).toBeVisible()
+    await expect(pillContainer.getByText('bridge', { exact: true })).toBeVisible()
+    await expect(pillContainer.getByText('deviceInfo', { exact: true })).toBeVisible()
+
+    // Details button should be highlighted (active view)
+    const detailsButton = modal.getByRole('button', { name: 'Details' })
+    const settingsButton = modal.getByRole('button', { name: 'Settings' })
+    const bridgeButton = modal.getByRole('button', { name: 'Bridge' })
+    await expect(detailsButton).toBeVisible()
+    await expect(settingsButton).toBeVisible()
+    await expect(bridgeButton).toBeVisible()
+
+    // Wait for camera details JSON to load
+    await expect(modal.locator('pre')).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+    console.log('Camera data modal opened with details view')
+
+    // Click Settings button
+    await settingsButton.click()
+    await expect(modal.locator('h3', { hasText: 'Camera Settings' })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Wait for settings JSON to load
+    await expect(modal.locator('pre')).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Include pills should show settings values
+    await expect(pillContainer.getByText('schema', { exact: true })).toBeVisible()
+    console.log('Switched to camera settings view')
+
+    // Click Bridge button
+    await bridgeButton.click()
+    await expect(modal.locator('h3', { hasText: 'Bridge Data' })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Wait for bridge JSON to load
+    await expect(modal.locator('pre')).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Include pills should show bridge values
+    await expect(pillContainer.getByText('networkInfo', { exact: true })).toBeVisible()
+    console.log('Switched to bridge data view')
+
+    // Click Details button to go back
+    await detailsButton.click()
+    await expect(modal.locator('h3', { hasText: 'Camera Data' })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(modal.locator('pre')).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+    console.log('Switched back to camera details view')
+
+    // Close modal with the X button
+    const closeButton = modal.locator('button').filter({ has: page.locator('svg path[d="M6 18L18 6M6 6l12 12"]') })
+    await closeButton.click()
+    await expect(modal).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Modal closed successfully')
+
+    // Reopen and close with ESC key
+    await infoButton.click()
+    await expect(modal).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await page.keyboard.press('Escape')
+    await expect(modal).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Modal closed with ESC key')
+
+    // Reopen and close with backdrop click
+    await infoButton.click()
+    await expect(modal).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    await modal.locator('.absolute.inset-0.bg-black\\/50').click({ position: { x: 10, y: 10 } })
+    await expect(modal).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Modal closed with backdrop click')
+
+    console.log('Camera data modal and map icon test completed successfully')
+  })
 })


### PR DESCRIPTION
## Summary
- Add (i) button next to Camera Information that opens a modal with full camera API response (all include parameters)
- Modal has Details, Settings, and Bridge view toggle buttons to fetch and display data from three different API endpoints
- Add red Google Maps pin icon next to camera name when location data is available, with address tooltip
- Add E2E test covering map icon, modal open/close, and view switching

## Test plan
- [x] All 21 E2E tests passing (including new camera data modal test)
- [ ] Verify (i) button opens modal with camera details JSON
- [ ] Verify Settings/Bridge buttons fetch and display correct API data
- [ ] Verify map icon links to correct Google Maps coordinates
- [ ] Verify modal closes via X button, ESC key, and backdrop click

🤖 Generated with [Claude Code](https://claude.com/claude-code)