### PR TITLE
Add 17 new E2E tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,32 +325,76 @@ src/
 └── main.ts                    # Application entry point
 
 tests/
-├── auth.spec.ts               # Authentication tests
-├── cameras.spec.ts            # Camera selection tests
-├── events.spec.ts             # Events system tests
-└── url-state.spec.ts          # URL parameter state persistence tests
+├── auth.spec.ts               # Authentication and user info modal tests (8)
+├── cameras.spec.ts            # Camera sidebar, selection, and info tests (11)
+├── dark-mode.spec.ts          # Dark mode toggle and URL parameter tests (2)
+├── event-types.spec.ts        # Event type selection and count tests (3)
+├── events.spec.ts             # Events and alerts panel tests (10)
+├── url-state.spec.ts          # URL parameter state persistence tests (1)
+└── user-info.spec.ts          # User info modal detail tests (3)
 ```
 
 ## Testing
 
-The project includes Playwright E2E tests covering:
+The project includes 38 Playwright E2E tests across 7 spec files:
 
-- OAuth login/logout flow
-- Camera sidebar and selection
-- Video player switching
-- Camera data modal (Details/Settings/Bridge views) and Google Maps link
-- Event type toggles
-- Events and alerts panels
-- URL state persistence across login/logout
+### Authentication (`auth.spec.ts` — 8 tests)
+- Redirect unauthenticated users to login page
+- Redirect unknown routes to login
+- Complete OAuth login flow
+- Show authenticated user info
+- Logout successfully
+- Open, close (ESC), and close (backdrop click) user info modal
 
-Run tests:
+### Camera Selection (`cameras.spec.ts` — 11 tests)
+- Display camera sidebar with cameras
+- Select camera and show main video player
+- Show camera info panel with details
+- Switch video player between cameras
+- Show camera status badges
+- Restore camera selection from URL after logout/login
+- Open Google Maps link and interact with camera data modal (Details/Settings/Bridge views)
+- Filter cameras by layout selection
+- Display exactly three cameras for test account
+- Show Bridge ID in camera info panel
+- Camera search/filter (gracefully skips if search input not available)
+
+### Dark Mode (`dark-mode.spec.ts` — 2 tests)
+- Toggle dark mode on/off and verify `dark` class on `<html>`
+- Dark mode URL parameter persistence through OAuth login flow
+
+### Event Types (`event-types.spec.ts` — 3 tests)
+- Toggle individual event types on/off with URL `events` parameter update
+- Select all / deselect all event types via "All" checkbox
+- Event type count indicator (e.g., "3/5 selected") updates on toggle
+
+### Events & Alerts (`events.spec.ts` — 10 tests)
+- Display three event panels (Event Types, Events, Alerts)
+- Show event type toggles with motion detection preselected
+- Toggle event types on/off
+- Show events panel content
+- Show alerts panel with controls
+- Change events time range (verify `ed` URL parameter)
+- Toggle auto-refresh checkbox (verify `er` URL parameter and countdown)
+- Toggle live events button (verify `live` URL parameter)
+- Change alerts time range (verify `ad` URL parameter)
+- Toggle event filter for alerts (verify `filter` URL parameter)
+
+### URL State Persistence (`url-state.spec.ts` — 1 test)
+- Restore camera selection and event type filters from URL after logout/login
+
+### User Info Modal (`user-info.spec.ts` — 3 tests)
+- Display base URL and copy to clipboard with feedback
+- Show masked access token, reveal via "Show & Copy", and copy feedback
+- Display token expiration timestamp and time remaining
+
+### Running Tests
+
 ```bash
-npm test
-```
-
-Run tests with UI:
-```bash
-npx playwright test --ui
+npm test                        # Run all tests
+npx playwright test --ui        # Interactive UI mode
+npm run test:headed             # Headed browser mode
+npx playwright test --list      # List all tests without running
 ```
 
 ## Configuration Notes

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ A Vue 3 single-page application for Eagle Eye Networks camera monitoring with li
 - **Live HD Video** - Full-quality live streaming using the EEN Live Video SDK
 - **Recorded Playback** - HLS video playback for historic events with precise timestamp seeking
 - **Camera Information Panel** - Display camera status, name, ID, and account info
+- **Google Maps Link** - Red map pin icon next to camera name when location data is available; opens Google Maps in a new tab with address tooltip
+- **Camera Data Modal** - Click the (i) button next to "Camera Information" to view full API data:
+  - **Details** view — full camera JSON with all include parameters
+  - **Settings** view — camera settings with schema and proposed values
+  - **Bridge** view — bridge details with all include parameters
+  - Include parameter pill badges shown for each view
+  - Copy to clipboard, close via X/ESC/backdrop click
 - **Event Playback Controls** - Click the event card to play/pause and seek to the event timestamp
 - **Keyboard Shortcuts** (recorded playback mode):
   - `Space` — Toggle play/pause
@@ -84,6 +91,7 @@ The bottom section of the application contains three panels for event management
 - **Event Data Modal** - View complete event JSON with syntax highlighting
 - **Alert Data Modal** - View complete alert JSON with syntax highlighting
 - **Notification Data Modal** - View notification JSON for alerts with notifications
+- **Camera Data Modal** - View camera details, settings, or bridge data with include parameter pills
 - **Copy to Clipboard** - One-click copy of JSON data
 - **ESC to Close** - Press Escape or click outside to close modals
 
@@ -222,7 +230,7 @@ This application uses the following functions from [een-api-toolkit](https://git
 
 - **Authentication:** `initEenToolkit`, `useAuthStore`, `getAuthUrl`, `handleAuthCallback`, `revokeToken`
 - **User:** `getCurrentUser`
-- **Devices:** `getCameras`, `getCamera`, `getLayouts`
+- **Devices:** `getCameras`, `getCamera`, `getCameraSettings`, `getBridge`, `getLayouts`
 - **Media:** `listFeeds`, `initMediaSession`, `listMedia`, `getRecordedImage`, `formatTimestamp`
 - **Events:** `listEvents`, `getEvent`, `listEventTypes`, `listEventFieldValues`, `getDataSchemasForEventType`, `getIncludeParameterForEventTypes`, `createEventSubscription`, `connectToEventSubscription`, `deleteEventSubscription`
 - **Alerts:** `listAlerts`, `listEventAlertConditionRules`, `listAlertActions`
@@ -309,6 +317,8 @@ src/
 │   └── index.ts               # Vue Router with auth guards
 ├── assets/
 │   └── main.css               # Tailwind CSS styles
+├── utils/
+│   └── eventTypeHash.ts       # DJB2 hash for URL event type encoding
 ├── types/
 │   └── een.ts                 # Type re-exports and helper types
 ├── App.vue                    # Root component with auth initialization
@@ -328,8 +338,10 @@ The project includes Playwright E2E tests covering:
 - OAuth login/logout flow
 - Camera sidebar and selection
 - Video player switching
+- Camera data modal (Details/Settings/Bridge views) and Google Maps link
 - Event type toggles
 - Events and alerts panels
+- URL state persistence across login/logout
 
 Run tests:
 ```bash

--- a/tests/cameras.spec.ts
+++ b/tests/cameras.spec.ts
@@ -61,7 +61,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
 
   // Check if we're on the EEN OAuth page or already redirected back
   const currentUrl = page.url()
-  if (currentUrl.includes('eagleeyenetworks.com')) {
+  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
     // Need to complete OAuth login form
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })

--- a/tests/cameras.spec.ts
+++ b/tests/cameras.spec.ts
@@ -10,6 +10,10 @@ dotenv.config()
  * 1. Camera sidebar displays cameras
  * 2. Camera selection updates main video
  * 3. Camera info panel shows details
+ * 4. Filter cameras by layout selection
+ * 5. Display three cameras for test account
+ * 6. Show Bridge ID in camera info panel
+ * 7. Show camera search and filter results
  */
 
 const TIMEOUTS = {
@@ -461,5 +465,171 @@ test.describe('Camera Selection and Video', () => {
     console.log('Modal closed with backdrop click')
 
     console.log('Camera data modal and map icon test completed successfully')
+  })
+
+  test('should filter cameras by layout selection', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera sidebar and cards to load
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const cameraCards = sidebar.locator('.camera-card')
+    await expect(cameraCards.first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Note initial camera count under "All Cameras"
+    const initialCount = await cameraCards.count()
+    console.log(`Initial camera count (All Cameras): ${initialCount}`)
+
+    // Get layout dropdown
+    const layoutSelect = sidebar.locator('select[title="Select layout"]')
+    await expect(layoutSelect).toBeVisible()
+
+    // Check available options
+    const options = layoutSelect.locator('option')
+    const optionCount = await options.count()
+    console.log(`Layout options available: ${optionCount}`)
+
+    if (optionCount > 1) {
+      // Find a layout option that isn't "All Cameras" or "URL-cameras"
+      let selectedLayout = false
+      for (let i = 0; i < optionCount; i++) {
+        const value = await options.nth(i).getAttribute('value')
+        if (value !== 'all' && value !== 'url') {
+          const text = await options.nth(i).textContent()
+          console.log(`Selecting layout: ${text} (value: ${value})`)
+          await layoutSelect.selectOption(value!)
+          await page.waitForTimeout(2000)
+          selectedLayout = true
+
+          // Camera list may have changed
+          const layoutCount = await cameraCards.count()
+          console.log(`Camera count after layout selection: ${layoutCount}`)
+          break
+        }
+      }
+
+      if (selectedLayout) {
+        // Switch back to "All Cameras"
+        await layoutSelect.selectOption('all')
+        await page.waitForTimeout(2000)
+
+        const restoredCount = await cameraCards.count()
+        console.log(`Camera count after restoring All Cameras: ${restoredCount}`)
+        expect(restoredCount).toBe(initialCount)
+      }
+    } else {
+      console.log('No additional layouts available, skipping layout filter test')
+    }
+
+    console.log('Layout filter test completed successfully')
+  })
+
+  test('should display three cameras for test account', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera sidebar and cards to load
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const cameraCards = sidebar.locator('.camera-card')
+    await expect(cameraCards.first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Count camera cards - should be exactly 3
+    const cardCount = await cameraCards.count()
+    console.log(`Found ${cardCount} camera(s)`)
+    expect(cardCount).toBe(3)
+
+    // Verify each camera has a name (h3 text) and status badge
+    for (let i = 0; i < cardCount; i++) {
+      const card = cameraCards.nth(i)
+      const name = await card.locator('h3').textContent()
+      expect(name).toBeTruthy()
+      expect(name!.length).toBeGreaterThan(0)
+
+      const statusBadge = card.locator('[class*="rounded-full"]')
+      await expect(statusBadge).toBeVisible()
+      const statusText = await statusBadge.textContent()
+      expect(statusText).toBeTruthy()
+
+      console.log(`Camera ${i + 1}: "${name}" - Status: ${statusText}`)
+    }
+
+    console.log('Three cameras display test completed successfully')
+  })
+
+  test('should show Bridge ID in camera info panel', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for main video player and camera info panel
+    const mainVideoPlayer = page.locator('.main-video-player')
+    await expect(mainVideoPlayer).toBeVisible({ timeout: TIMEOUTS.VIDEO_LOAD })
+    await expect(mainVideoPlayer.getByText('Camera Information')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify "Bridge ID" label exists
+    const bridgeIdLabel = mainVideoPlayer.locator('label', { hasText: 'Bridge ID' })
+    await expect(bridgeIdLabel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify the bridge ID value is displayed (non-empty monospace text next to the label)
+    const bridgeIdValue = mainVideoPlayer.locator('label:has-text("Bridge ID") + p')
+    await expect(bridgeIdValue).toBeVisible()
+    const bridgeIdText = await bridgeIdValue.textContent()
+    expect(bridgeIdText).toBeTruthy()
+    expect(bridgeIdText!.trim().length).toBeGreaterThan(0)
+    console.log(`Bridge ID: ${bridgeIdText}`)
+
+    console.log('Bridge ID display test completed successfully')
+  })
+
+  test('should show camera search and filter results', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera sidebar and cards to load
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const cameraCards = sidebar.locator('.camera-card')
+    await expect(cameraCards.first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Get the name of the first camera
+    const firstName = await cameraCards.first().locator('h3').textContent()
+    console.log(`First camera name: ${firstName}`)
+
+    // Look for search input in sidebar
+    const searchInput = sidebar.locator('input[type="text"], input[type="search"], input[placeholder*="search" i], input[placeholder*="filter" i]')
+    const searchExists = await searchInput.isVisible().catch(() => false)
+
+    if (searchExists) {
+      // Type a partial camera name
+      const partialName = firstName!.substring(0, 3)
+      console.log(`Searching for: ${partialName}`)
+      await searchInput.fill(partialName)
+      await page.waitForTimeout(1000)
+
+      // Verify filtered results
+      const filteredCount = await cameraCards.count()
+      console.log(`Filtered results: ${filteredCount}`)
+      expect(filteredCount).toBeGreaterThan(0)
+
+      // Clear search
+      await searchInput.clear()
+      await page.waitForTimeout(1000)
+    } else {
+      console.log('No search input found in camera sidebar - search feature not available')
+    }
+
+    console.log('Camera search test completed successfully')
   })
 })

--- a/tests/cameras.spec.ts
+++ b/tests/cameras.spec.ts
@@ -61,7 +61,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
 
   // Check if we're on the EEN OAuth page or already redirected back
   const currentUrl = page.url()
-  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
     // Need to complete OAuth login form
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })

--- a/tests/dark-mode.spec.ts
+++ b/tests/dark-mode.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect, Page } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * E2E tests for Dark Mode
+ *
+ * Tests:
+ * 1. Toggle dark mode and persist preference
+ * 2. Respect dark mode URL parameter
+ */
+
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 60000,
+  UI_UPDATE: 10000,
+  CAMERA_LOAD: 20000,
+  PROXY_CHECK: 5000
+} as const
+
+const TEST_USER = process.env.TEST_USER
+const TEST_PASSWORD = process.env.TEST_PASSWORD
+const PROXY_URL = process.env.VITE_PROXY_URL
+
+async function isProxyAccessible(): Promise<boolean> {
+  if (!PROXY_URL) return false
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.PROXY_CHECK)
+
+  try {
+    const response = await fetch(PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login')
+  await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+  await Promise.race([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.OAUTH_REDIRECT })
+  ])
+
+  const currentUrl = page.url()
+  if (currentUrl.includes('eagleeyenetworks.com')) {
+    const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(username)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill(password)
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+  }
+
+  await page.waitForFunction(
+    () => window.location.pathname === '/' && !window.location.search.includes('code='),
+    { timeout: TIMEOUTS.AUTH_COMPLETE }
+  )
+}
+
+async function clearAuthState(page: Page): Promise<void> {
+  try {
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore
+        }
+      })
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+test.describe('Dark Mode', () => {
+  let proxyAccessible = false
+
+  function skipIfNoProxy() {
+    test.skip(!proxyAccessible, 'OAuth proxy not accessible')
+  }
+
+  function skipIfNoCredentials() {
+    test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
+  }
+
+  test.beforeAll(async () => {
+    proxyAccessible = await isProxyAccessible()
+    if (!proxyAccessible) {
+      console.log('OAuth proxy not accessible - dark mode tests will be skipped')
+    }
+  })
+
+  test.afterEach(async ({ page }) => {
+    await clearAuthState(page)
+  })
+
+  test('should toggle dark mode and persist preference', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for app to load
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Find the dark mode toggle button
+    const darkToggle = page.locator('button[title="Switch to dark mode"], button[title="Switch to light mode"]')
+    await expect(darkToggle).toBeVisible()
+
+    // Check initial state
+    const initialTitle = await darkToggle.getAttribute('title')
+    const initialIsDark = initialTitle === 'Switch to light mode'
+    console.log(`Initial dark mode state: ${initialIsDark}`)
+
+    // Click to toggle dark mode
+    await darkToggle.click()
+    await page.waitForTimeout(500)
+
+    // Verify state changed
+    if (initialIsDark) {
+      // Was dark, now should be light
+      await expect(page.locator('html:not(.dark)')).toBeAttached()
+      await expect(page.locator('button[title="Switch to dark mode"]')).toBeVisible()
+    } else {
+      // Was light, now should be dark
+      await expect(page.locator('html.dark')).toBeAttached()
+      await expect(page.locator('button[title="Switch to light mode"]')).toBeVisible()
+    }
+    console.log('Toggled dark mode successfully')
+
+    // Toggle back
+    await darkToggle.click()
+    await page.waitForTimeout(500)
+
+    // Verify restored to original state
+    if (initialIsDark) {
+      await expect(page.locator('html.dark')).toBeAttached()
+      await expect(page.locator('button[title="Switch to light mode"]')).toBeVisible()
+    } else {
+      await expect(page.locator('html:not(.dark)')).toBeAttached()
+      await expect(page.locator('button[title="Switch to dark mode"]')).toBeVisible()
+    }
+    console.log('Dark mode toggle test completed successfully')
+  })
+
+  test('should respect dark mode URL parameter', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // First, enable dark mode via toggle to get dark=1 in URL
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Ensure we start in light mode
+    const darkToggle = page.locator('button[title="Switch to dark mode"], button[title="Switch to light mode"]')
+    await expect(darkToggle).toBeVisible()
+    const initialTitle = await darkToggle.getAttribute('title')
+    if (initialTitle === 'Switch to light mode') {
+      // Currently dark, switch to light first
+      await darkToggle.click()
+      await page.waitForTimeout(500)
+    }
+
+    // Now toggle to dark mode
+    await page.locator('button[title="Switch to dark mode"]').click()
+    await page.waitForTimeout(500)
+
+    // Verify URL contains dark=1
+    expect(page.url()).toContain('dark=1')
+    await expect(page.locator('html.dark')).toBeAttached()
+    console.log('Dark mode enabled, URL contains dark=1')
+
+    // Capture URL with dark=1
+    const darkUrl = page.url()
+
+    // Toggle back to light mode
+    await page.locator('button[title="Switch to light mode"]').click()
+    await page.waitForTimeout(500)
+
+    // Verify dark=1 removed from URL
+    expect(page.url()).not.toContain('dark=1')
+    await expect(page.locator('html:not(.dark)')).toBeAttached()
+    console.log('Light mode restored, dark=1 removed from URL')
+
+    // Now test that dark=1 persists through login flow via sessionStorage
+    // Logout
+    await page.getByRole('link', { name: /logout/i }).click()
+    await expect(page.getByRole('heading', { name: /logged out/i })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Clear auth state but preserve sessionStorage for dark mode
+    await page.evaluate(() => {
+      try { localStorage.clear() } catch { /* ignore */ }
+    })
+
+    // Navigate to the dark URL (triggers sessionStorage save via router guard)
+    await page.goto(darkUrl)
+    await expect(page).toHaveURL('/login')
+
+    // Login again - dark mode should be restored from sessionStorage
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify dark mode is active (restored from URL parameter via sessionStorage)
+    await expect(page.locator('html.dark')).toBeAttached({ timeout: TIMEOUTS.UI_UPDATE })
+    await expect(page.locator('button[title="Switch to light mode"]')).toBeVisible()
+    console.log('Dark mode restored via URL parameter through login flow')
+
+    console.log('Dark mode URL parameter test completed successfully')
+  })
+})

--- a/tests/dark-mode.spec.ts
+++ b/tests/dark-mode.spec.ts
@@ -53,7 +53,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (currentUrl.includes('eagleeyenetworks.com')) {
+  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)

--- a/tests/dark-mode.spec.ts
+++ b/tests/dark-mode.spec.ts
@@ -53,7 +53,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)

--- a/tests/event-types.spec.ts
+++ b/tests/event-types.spec.ts
@@ -55,7 +55,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)

--- a/tests/event-types.spec.ts
+++ b/tests/event-types.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, Page } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * E2E tests for Event Types Panel
+ *
+ * Tests:
+ * 1. Toggle individual event types on and off
+ * 2. Select all and deselect all event types
+ * 3. Show event type count indicator
+ */
+
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 60000,
+  UI_UPDATE: 10000,
+  CAMERA_LOAD: 20000,
+  EVENTS_LOAD: 15000,
+  PROXY_CHECK: 5000
+} as const
+
+const TEST_USER = process.env.TEST_USER
+const TEST_PASSWORD = process.env.TEST_PASSWORD
+const PROXY_URL = process.env.VITE_PROXY_URL
+
+async function isProxyAccessible(): Promise<boolean> {
+  if (!PROXY_URL) return false
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.PROXY_CHECK)
+
+  try {
+    const response = await fetch(PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login')
+  await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+  await Promise.race([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.OAUTH_REDIRECT })
+  ])
+
+  const currentUrl = page.url()
+  if (currentUrl.includes('eagleeyenetworks.com')) {
+    const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(username)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill(password)
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+  }
+
+  await page.waitForFunction(
+    () => window.location.pathname === '/' && !window.location.search.includes('code='),
+    { timeout: TIMEOUTS.AUTH_COMPLETE }
+  )
+}
+
+async function clearAuthState(page: Page): Promise<void> {
+  try {
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore
+        }
+      })
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+test.describe('Event Types Panel', () => {
+  let proxyAccessible = false
+
+  function skipIfNoProxy() {
+    test.skip(!proxyAccessible, 'OAuth proxy not accessible')
+  }
+
+  function skipIfNoCredentials() {
+    test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
+  }
+
+  test.beforeAll(async () => {
+    proxyAccessible = await isProxyAccessible()
+    if (!proxyAccessible) {
+      console.log('OAuth proxy not accessible - event types tests will be skipped')
+    }
+  })
+
+  test.afterEach(async ({ page }) => {
+    await clearAuthState(page)
+  })
+
+  test('should toggle individual event types on and off', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    const eventTypesPanel = page.locator('.event-types-panel')
+    await expect(eventTypesPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Wait for individual event type checkboxes to load (skip first which is "All")
+    const allCheckboxes = eventTypesPanel.locator('input[type="checkbox"]')
+    await expect(allCheckboxes.first()).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    const totalCheckboxes = await allCheckboxes.count()
+    // Individual checkboxes start at index 1 (index 0 is "All")
+    expect(totalCheckboxes).toBeGreaterThan(1)
+
+    // Get initial checked count (individual only, skip "All" at index 0)
+    let initialCheckedCount = 0
+    for (let i = 1; i < totalCheckboxes; i++) {
+      if (await allCheckboxes.nth(i).isChecked()) initialCheckedCount++
+    }
+    console.log(`Initial checked count: ${initialCheckedCount}`)
+
+    // Find a checked individual checkbox and uncheck it
+    let toggledIndex = -1
+    for (let i = 1; i < totalCheckboxes; i++) {
+      if (await allCheckboxes.nth(i).isChecked()) {
+        toggledIndex = i
+        await allCheckboxes.nth(i).click()
+        break
+      }
+    }
+
+    if (toggledIndex === -1) {
+      console.log('No checked event types found, checking one instead')
+      toggledIndex = 1
+      await allCheckboxes.nth(1).click()
+    }
+
+    await page.waitForTimeout(500)
+
+    // Verify URL updated (events parameter should change)
+    const urlAfterUncheck = page.url()
+    console.log(`URL after toggle: ${urlAfterUncheck}`)
+
+    // Re-check the same event type
+    await allCheckboxes.nth(toggledIndex).click()
+    await page.waitForTimeout(500)
+
+    // Verify count returns to original
+    let restoredCount = 0
+    for (let i = 1; i < totalCheckboxes; i++) {
+      if (await allCheckboxes.nth(i).isChecked()) restoredCount++
+    }
+    expect(restoredCount).toBe(initialCheckedCount)
+    console.log('Individual event type toggle test completed successfully')
+  })
+
+  test('should select all and deselect all event types', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    const eventTypesPanel = page.locator('.event-types-panel')
+    await expect(eventTypesPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const allCheckboxes = eventTypesPanel.locator('input[type="checkbox"]')
+    await expect(allCheckboxes.first()).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    const totalCheckboxes = await allCheckboxes.count()
+    const individualCount = totalCheckboxes - 1 // Exclude "All" checkbox
+
+    // The "All" checkbox is the first one
+    const allCheckbox = allCheckboxes.first()
+
+    // Click "All" to select all
+    const isAllChecked = await allCheckbox.isChecked()
+    if (!isAllChecked) {
+      await allCheckbox.click()
+      await page.waitForTimeout(500)
+    }
+
+    // Verify all individual checkboxes are checked
+    for (let i = 1; i < totalCheckboxes; i++) {
+      await expect(allCheckboxes.nth(i)).toBeChecked()
+    }
+    console.log(`All ${individualCount} event types selected`)
+
+    // Click "All" again to deselect all
+    await allCheckbox.click()
+    await page.waitForTimeout(500)
+
+    // Verify all individual checkboxes are unchecked
+    for (let i = 1; i < totalCheckboxes; i++) {
+      await expect(allCheckboxes.nth(i)).not.toBeChecked()
+    }
+    console.log('All event types deselected')
+
+    // Verify URL events parameter is removed when none selected
+    const url = page.url()
+    const urlParams = new URL(url).searchParams
+    expect(urlParams.has('events')).toBe(false)
+    console.log('Select all / deselect all test completed successfully')
+  })
+
+  test('should show event type count indicator', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    const eventTypesPanel = page.locator('.event-types-panel')
+    await expect(eventTypesPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const allCheckboxes = eventTypesPanel.locator('input[type="checkbox"]')
+    await expect(allCheckboxes.first()).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    // Verify the count text appears (e.g., "3/5 selected")
+    const countText = eventTypesPanel.locator('text=/\\d+\\/\\d+ selected/')
+    await expect(countText).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    const initialText = await countText.textContent()
+    console.log(`Initial count: ${initialText}`)
+
+    // Toggle an event type and verify count updates
+    const totalCheckboxes = await allCheckboxes.count()
+    if (totalCheckboxes > 1) {
+      // Find a checked individual checkbox and uncheck it
+      for (let i = 1; i < totalCheckboxes; i++) {
+        if (await allCheckboxes.nth(i).isChecked()) {
+          await allCheckboxes.nth(i).click()
+          break
+        }
+      }
+      await page.waitForTimeout(500)
+
+      const updatedText = await countText.textContent()
+      console.log(`Updated count: ${updatedText}`)
+      expect(updatedText).not.toBe(initialText)
+    }
+
+    console.log('Event type count indicator test completed successfully')
+  })
+})

--- a/tests/event-types.spec.ts
+++ b/tests/event-types.spec.ts
@@ -55,7 +55,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (currentUrl.includes('eagleeyenetworks.com')) {
+  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -11,6 +11,11 @@ dotenv.config()
  * 2. Motion detection is preselected
  * 3. Events panel loads events
  * 4. Alerts panel shows SSE connection
+ * 5. Change events time range
+ * 6. Toggle auto-refresh checkbox in events panel
+ * 7. Toggle live events button
+ * 8. Change alerts time range
+ * 9. Toggle event filter for alerts
  */
 
 const TIMEOUTS = {
@@ -257,5 +262,222 @@ test.describe('Events System', () => {
     await expect(alertsPanel.locator('input[type="checkbox"]')).toBeVisible()
 
     console.log('Alerts panel test completed successfully')
+  })
+
+  test('should change events time range', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera selection
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar.locator('.camera-card').first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Events panel
+    const eventsPanel = page.locator('.events-panel')
+    await expect(eventsPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Get the time range dropdown
+    const timeRangeSelect = eventsPanel.locator('select')
+    await expect(timeRangeSelect).toBeVisible()
+
+    // Change to "Last 24h" (value 1440)
+    await timeRangeSelect.selectOption({ label: 'Last 24h' })
+    await page.waitForTimeout(1000)
+
+    // Verify URL updates with ed=24h
+    expect(page.url()).toContain('ed=24h')
+    console.log('Changed to Last 24h, URL contains ed=24h')
+
+    // Change to "Last 10 min" (value 10)
+    await timeRangeSelect.selectOption({ label: 'Last 10 min' })
+    await page.waitForTimeout(1000)
+
+    // Verify URL updates with ed=10m
+    expect(page.url()).toContain('ed=10m')
+    console.log('Changed to Last 10 min, URL contains ed=10m')
+
+    console.log('Events time range test completed successfully')
+  })
+
+  test('should toggle auto-refresh checkbox in events panel', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera selection
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar.locator('.camera-card').first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Events panel - use EVENTS_LOAD timeout as it may take time to appear after camera selection
+    const eventsPanel = page.locator('.events-panel')
+    await expect(eventsPanel).toBeVisible({ timeout: TIMEOUTS.EVENTS_LOAD })
+
+    // Find auto-refresh checkbox
+    const autoRefreshCheckbox = eventsPanel.locator('input[type="checkbox"][title="Auto-refresh every minute"]')
+    await expect(autoRefreshCheckbox).toBeVisible()
+
+    // Check initial state
+    const initialChecked = await autoRefreshCheckbox.isChecked()
+    console.log(`Initial auto-refresh state: ${initialChecked}`)
+
+    // Toggle it on
+    if (!initialChecked) {
+      await autoRefreshCheckbox.click()
+      await page.waitForTimeout(500)
+
+      // Verify URL parameter er=1 appears
+      expect(page.url()).toContain('er=1')
+      console.log('Auto-refresh enabled, URL contains er=1')
+
+      // Verify refresh button shows countdown text (wait for loading to finish)
+      const refreshBtn = eventsPanel.getByTitle('Refresh events')
+      await expect(refreshBtn).not.toHaveText('Loading...', { timeout: TIMEOUTS.EVENTS_LOAD })
+      const refreshText = await refreshBtn.textContent()
+      console.log(`Refresh button text: ${refreshText}`)
+      expect(refreshText).toMatch(/Refresh in \d+/)
+    }
+
+    // Toggle it off
+    await autoRefreshCheckbox.click()
+    await page.waitForTimeout(500)
+
+    if (!initialChecked) {
+      // Was off, turned on, now off again - er should not be in URL
+      expect(page.url()).not.toContain('er=1')
+      console.log('Auto-refresh disabled, er removed from URL')
+    }
+
+    console.log('Auto-refresh toggle test completed successfully')
+  })
+
+  test('should toggle live events button', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera selection
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar.locator('.camera-card').first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Events panel
+    const eventsPanel = page.locator('.events-panel')
+    await expect(eventsPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Find live events button
+    const liveButton = eventsPanel.getByTitle('Toggle live event feed')
+    await expect(liveButton).toBeVisible()
+
+    // Verify initial state - should show "Turn Live Events On" with gray styling
+    const initialText = await liveButton.textContent()
+    console.log(`Initial live button text: ${initialText}`)
+    expect(initialText).toContain('Turn Live Events On')
+
+    // Click to enable live events
+    await liveButton.click()
+    await page.waitForTimeout(2000)
+
+    // Verify button changes - could be "Connecting..." or "Disable Live Events"
+    const afterClickText = await liveButton.textContent()
+    console.log(`After click live button text: ${afterClickText}`)
+    expect(afterClickText).toMatch(/Connecting|Disable Live Events/)
+
+    // Verify URL parameter live=1 appears
+    expect(page.url()).toContain('live=1')
+    console.log('Live events enabled, URL contains live=1')
+
+    // Click again to disable
+    await liveButton.click()
+    await page.waitForTimeout(1000)
+
+    // Verify button reverts to "Turn Live Events On"
+    const revertedText = await liveButton.textContent()
+    console.log(`Reverted live button text: ${revertedText}`)
+    expect(revertedText).toContain('Turn Live Events On')
+
+    // Verify live parameter removed from URL
+    expect(page.url()).not.toContain('live=1')
+    console.log('Live events toggle test completed successfully')
+  })
+
+  test('should change alerts time range', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera selection
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar.locator('.camera-card').first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Alerts panel
+    const alertsPanel = page.locator('.alerts-panel')
+    await expect(alertsPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Get the time range dropdown
+    const timeRangeSelect = alertsPanel.locator('select')
+    await expect(timeRangeSelect).toBeVisible()
+
+    // Change to "Last week" (value 10080)
+    await timeRangeSelect.selectOption({ label: 'Last week' })
+    await page.waitForTimeout(1000)
+
+    // Verify URL updates with ad=1w
+    expect(page.url()).toContain('ad=1w')
+    console.log('Changed alerts to Last week, URL contains ad=1w')
+
+    console.log('Alerts time range test completed successfully')
+  })
+
+  test('should toggle event filter for alerts', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for camera selection
+    const sidebar = page.locator('.camera-sidebar')
+    await expect(sidebar.locator('.camera-card').first()).toBeVisible({ timeout: TIMEOUTS.CAMERA_LOAD })
+
+    // Alerts panel
+    const alertsPanel = page.locator('.alerts-panel')
+    await expect(alertsPanel).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Find event filter button
+    const filterButton = alertsPanel.getByTitle('Filter alerts by selected event types')
+    await expect(filterButton).toBeVisible()
+
+    // Verify initial state - should show "Enable Event Filter"
+    const initialText = await filterButton.textContent()
+    console.log(`Initial filter button text: ${initialText}`)
+    expect(initialText).toContain('Enable Event Filter')
+
+    // Click to enable
+    await filterButton.click()
+    await page.waitForTimeout(1000)
+
+    // Verify button changes color and text
+    const enabledText = await filterButton.textContent()
+    console.log(`Enabled filter button text: ${enabledText}`)
+    expect(enabledText).toContain('Disable Event Filter')
+
+    // Verify URL parameter filter=1 appears
+    expect(page.url()).toContain('filter=1')
+    console.log('Event filter enabled, URL contains filter=1')
+
+    // Click to disable
+    await filterButton.click()
+    await page.waitForTimeout(1000)
+
+    // Verify button reverts
+    const disabledText = await filterButton.textContent()
+    expect(disabledText).toContain('Enable Event Filter')
+
+    // Verify filter parameter removed from URL
+    expect(page.url()).not.toContain('filter=1')
+    console.log('Event filter toggle test completed successfully')
   })
 })

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -317,7 +317,7 @@ test.describe('Events System', () => {
 
     // Find auto-refresh checkbox
     const autoRefreshCheckbox = eventsPanel.locator('input[type="checkbox"][title="Auto-refresh every minute"]')
-    await expect(autoRefreshCheckbox).toBeVisible()
+    await expect(autoRefreshCheckbox).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
 
     // Check initial state
     const initialChecked = await autoRefreshCheckbox.isChecked()

--- a/tests/url-state.spec.ts
+++ b/tests/url-state.spec.ts
@@ -56,7 +56,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
 
   // Check if we're on the EEN OAuth page or already redirected back
   const currentUrl = page.url()
-  if (currentUrl.includes('eagleeyenetworks.com')) {
+  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
     // Need to complete OAuth login form
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })

--- a/tests/url-state.spec.ts
+++ b/tests/url-state.spec.ts
@@ -56,7 +56,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
 
   // Check if we're on the EEN OAuth page or already redirected back
   const currentUrl = page.url()
-  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
     // Need to complete OAuth login form
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })

--- a/tests/user-info.spec.ts
+++ b/tests/user-info.spec.ts
@@ -53,7 +53,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (currentUrl.includes('eagleeyenetworks.com')) {
+  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)

--- a/tests/user-info.spec.ts
+++ b/tests/user-info.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect, Page } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * E2E tests for User Info Modal
+ *
+ * Tests:
+ * 1. Display base URL and copy it to clipboard
+ * 2. Show and copy access token
+ * 3. Display token expiration info
+ */
+
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 60000,
+  UI_UPDATE: 10000,
+  PROXY_CHECK: 5000
+} as const
+
+const TEST_USER = process.env.TEST_USER
+const TEST_PASSWORD = process.env.TEST_PASSWORD
+const PROXY_URL = process.env.VITE_PROXY_URL
+
+async function isProxyAccessible(): Promise<boolean> {
+  if (!PROXY_URL) return false
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.PROXY_CHECK)
+
+  try {
+    const response = await fetch(PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login')
+  await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+  await Promise.race([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.OAUTH_REDIRECT })
+  ])
+
+  const currentUrl = page.url()
+  if (currentUrl.includes('eagleeyenetworks.com')) {
+    const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(username)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill(password)
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+  }
+
+  await page.waitForFunction(
+    () => window.location.pathname === '/' && !window.location.search.includes('code='),
+    { timeout: TIMEOUTS.AUTH_COMPLETE }
+  )
+}
+
+async function clearAuthState(page: Page): Promise<void> {
+  try {
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore
+        }
+      })
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+async function openUserInfoModal(page: Page): Promise<void> {
+  const usernameButton = page.locator('header button').filter({ hasText: /\w+ \w+/ }).first()
+  await expect(usernameButton).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+  await usernameButton.click()
+  await expect(page.getByRole('heading', { name: 'User Info' })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+}
+
+test.describe('User Info Modal', () => {
+  let proxyAccessible = false
+
+  function skipIfNoProxy() {
+    test.skip(!proxyAccessible, 'OAuth proxy not accessible')
+  }
+
+  function skipIfNoCredentials() {
+    test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
+  }
+
+  test.beforeAll(async () => {
+    proxyAccessible = await isProxyAccessible()
+    if (!proxyAccessible) {
+      console.log('OAuth proxy not accessible - user info tests will be skipped')
+    }
+  })
+
+  test.afterEach(async ({ page }) => {
+    await clearAuthState(page)
+  })
+
+  test('should display base URL and copy it to clipboard', async ({ page, context }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // Grant clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await openUserInfoModal(page)
+
+    // Verify Base URL section is visible
+    await expect(page.getByText('Base URL')).toBeVisible()
+
+    // Find the base URL code element - it should contain a non-empty URL
+    const baseUrlCode = page.locator('code').first()
+    await expect(baseUrlCode).toBeVisible()
+    const baseUrlText = await baseUrlCode.textContent()
+    expect(baseUrlText).toBeTruthy()
+    expect(baseUrlText!.length).toBeGreaterThan(0)
+    console.log(`Base URL displayed: ${baseUrlText}`)
+
+    // Click the copy button next to Base URL
+    const copyBaseUrlBtn = page.getByTitle('Copy Base URL')
+    await expect(copyBaseUrlBtn).toBeVisible()
+    await copyBaseUrlBtn.click()
+
+    // Verify copy feedback - title changes to "Copied!"
+    await expect(page.getByTitle('Copied!').first()).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Base URL copy test completed successfully')
+  })
+
+  test('should show and copy access token', async ({ page, context }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    // Grant clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await openUserInfoModal(page)
+
+    // Verify Access Token section is visible
+    await expect(page.getByText('Access Token')).toBeVisible()
+
+    // Token should be hidden by default (shows dots)
+    const tokenCode = page.locator('code').nth(1)
+    await expect(tokenCode).toBeVisible()
+    const maskedText = await tokenCode.textContent()
+    expect(maskedText).toContain('•')
+    console.log('Token is masked by default')
+
+    // Click "Show & Copy" button
+    const showCopyBtn = page.getByRole('button', { name: /Show & Copy/i })
+    await expect(showCopyBtn).toBeVisible()
+    await showCopyBtn.click()
+
+    // Verify token is revealed (no longer dots)
+    await page.waitForTimeout(500)
+    const revealedText = await tokenCode.textContent()
+    expect(revealedText).not.toContain('•')
+    expect(revealedText!.length).toBeGreaterThan(10)
+    console.log('Token revealed successfully')
+
+    // Verify copy feedback - button text changes
+    const copiedOrCopy = page.getByRole('button', { name: /Copied!|^Copy$/i })
+    await expect(copiedOrCopy).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Access token show and copy test completed successfully')
+  })
+
+  test('should display token expiration info', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await openUserInfoModal(page)
+
+    // Verify expiration timestamp is shown
+    await expect(page.getByText('Expires:')).toBeVisible()
+
+    // Verify time remaining is displayed (non-empty text)
+    await expect(page.getByText('Time remaining:')).toBeVisible()
+
+    // Get the time remaining text to verify it's meaningful
+    const timeRemainingText = await page.getByText('Time remaining:').textContent()
+    expect(timeRemainingText).toBeTruthy()
+    expect(timeRemainingText!.length).toBeGreaterThan('Time remaining:'.length)
+    console.log(`Token expiration info: ${timeRemainingText}`)
+
+    // Close modal
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('heading', { name: 'User Info' })).not.toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Token expiration info test completed successfully')
+  })
+})

--- a/tests/user-info.spec.ts
+++ b/tests/user-info.spec.ts
@@ -53,7 +53,7 @@ async function performLogin(page: Page, username: string, password: string): Pro
   ])
 
   const currentUrl = page.url()
-  if (new URL(currentUrl).hostname.endsWith('eagleeyenetworks.com')) {
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
     const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
     await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
     await emailInput.fill(username)


### PR DESCRIPTION
## Summary
- Added 17 new Playwright E2E tests expanding coverage from 21 to 38 tests across 7 spec files
- New test files: `dark-mode.spec.ts` (2 tests), `event-types.spec.ts` (3 tests), `user-info.spec.ts` (3 tests)
- Extended `cameras.spec.ts` (+4 tests: layout filter, 3-camera count, Bridge ID, search) and `events.spec.ts` (+5 tests: time range, auto-refresh, live events, alerts time range, event filter)
- Updated README with comprehensive per-file test documentation and updated project structure

## Test plan
- [x] All 38 Playwright E2E tests pass (`npx playwright test`)
- [ ] Verify tests skip gracefully when proxy is not accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)