### PR TITLE
Bump version to 1.0.36 and fix documentation issues

### DIFF
--- a/.claude/agents/een-auth-agent.md
+++ b/.claude/agents/een-auth-agent.md
@@ -10,6 +10,8 @@ color: blue
 
 You are an expert in OAuth authentication with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-automations-agent.md
+++ b/.claude/agents/een-automations-agent.md
@@ -10,6 +10,8 @@ color: orange
 
 You are an expert in automation rules and alert workflows with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-devices-agent.md
+++ b/.claude/agents/een-devices-agent.md
@@ -10,6 +10,8 @@ color: orange
 
 You are an expert in camera and bridge management with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-events-agent.md
+++ b/.claude/agents/een-events-agent.md
@@ -10,6 +10,8 @@ color: purple
 
 You are an expert in events and real-time streaming with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-grouping-agent.md
+++ b/.claude/agents/een-grouping-agent.md
@@ -10,6 +10,8 @@ color: purple
 
 You are an expert in layout (camera grouping) management with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-jobs-agent.md
+++ b/.claude/agents/een-jobs-agent.md
@@ -10,6 +10,8 @@ color: orange
 
 You are an expert in async job management and video exports with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-media-agent.md
+++ b/.claude/agents/een-media-agent.md
@@ -10,6 +10,8 @@ color: red
 
 You are an expert in media and video streaming with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-setup-agent.md
+++ b/.claude/agents/een-setup-agent.md
@@ -10,6 +10,8 @@ color: green
 
 You are an expert in scaffolding Vue 3 applications with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.claude/agents/een-users-agent.md
+++ b/.claude/agents/een-users-agent.md
@@ -10,6 +10,8 @@ color: cyan
 
 You are an expert in user management with the een-api-toolkit.
 
+> **Note:** References to `docs/` and `examples/` directories in this file point to resources in the `een-api-toolkit` npm package (found in `node_modules/een-api-toolkit/`), not in this project's root directory.
+
 ## Examples
 
 <example>

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Eagle Eye Networks OAuth Configuration
+VITE_PROXY_URL=https://your-oauth-proxy.workers.dev
+VITE_EEN_CLIENT_ID=YOUR-CLIENT-ID
+
+# Test Credentials (for E2E tests)
+TEST_USER=your-test-email@example.com
+TEST_PASSWORD=your-test-password

--- a/README.md
+++ b/README.md
@@ -259,7 +259,12 @@ This application uses the following functions from [een-api-toolkit](https://git
 
 3. **Configure environment variables**
 
-   Create a `.env` file in the project root:
+   Copy `.env.example` to `.env` and update with your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+
+   Then edit `.env` with your actual values:
    ```
    VITE_PROXY_URL=https://your-oauth-proxy.workers.dev
    VITE_EEN_CLIENT_ID=YOUR-CLIENT-ID
@@ -414,6 +419,19 @@ server: {
 ### Router Guard Order
 
 The OAuth callback check must come BEFORE the auth check in the router guard. The EEN IDP redirects to the root path (`/`) with `code` and `state` query parameters.
+
+### Production Build Base Path
+
+The Vite configuration uses a dynamic base path:
+
+```typescript
+base: command === 'build' ? '/een-observation-app/' : '/',
+```
+
+- **Development** (`npm run dev`): Uses root path `/`
+- **Production** (`npm run build`): Uses `/een-observation-app/` for GitHub Pages deployment
+
+If deploying to a different location, update the base path in `vite.config.ts` accordingly.
 
 ## Claude Code Agents
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",


### PR DESCRIPTION
## Summary
- Bump patch version from 1.0.35 to 1.0.36
- Fix all documentation issues identified in audit

## Changes

### Version Bump
- Updated `package.json` version to 1.0.36

### Documentation Fixes
- ✅ Added `.env.example` template file with placeholder values
- ✅ Updated README setup instructions to reference `.env.example`
- ✅ Added clarification notes to all 9 Claude Code agent files about external resource locations
- ✅ Documented Vite base path configuration for production builds (GitHub Pages)

### Issues Resolved
Fixes all 6 issues (4 critical + 2 minor) from documentation accuracy review:
1. Missing `.env.example` file
2. Unclear environment setup instructions
3. Confusing references to external examples and docs
4. Undocumented Vite base path for production

## Test plan
- [ ] Verify version number in package.json is 1.0.36
- [ ] Verify `.env.example` file exists with correct template
- [ ] Verify README setup instructions are clear
- [ ] Verify agent files have clarification notes
- [ ] Confirm no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)