### PR TITLE
Add Shift+Arrow 0.5s seek and update een-api-toolkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Vue 3 single-page application for Eagle Eye Networks camera monitoring. Uses the `een-api-toolkit` npm package for all API interactions (auth, cameras, events, alerts, media, exports). Live video via `@een/live-video-web-sdk`, recorded playback via `hls.js`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start dev server at `http://127.0.0.1:3333` (kills existing port 3333 process first) |
+| `npm run build` | Type-check with `vue-tsc --noEmit` then build with Vite |
+| `npm test` | Run all 38 Playwright E2E tests (requires dev server + OAuth proxy) |
+| `npx playwright test tests/events.spec.ts` | Run a single test file |
+| `npx playwright test -g "should toggle dark mode"` | Run a single test by name |
+| `npx playwright test --ui` | Interactive Playwright UI |
+| `npx playwright test --headed` | Tests in visible browser |
+
+## Testing Notes
+
+- Tests run sequentially (`workers: 1`, `fullyParallel: false`), no retries, 60s timeout
+- Tests perform real OAuth login against EEN servers; requires `.env` with `TEST_USER` and `TEST_PASSWORD`
+- Auth state cached in `.auth-state.json` for reuse across specs
+- The `performLogin()` helper handles the 2-step OAuth flow (email → Next → password → Sign in)
+- Dev server auto-starts via Playwright's `webServer` config unless already running
+
+## Architecture
+
+### Routing & Auth Flow
+- **Router guard order matters**: OAuth callback check (looking for `code`/`state` params) MUST come before the auth check, because EEN IDP redirects to `/` with those params.
+- URL params are saved to sessionStorage before OAuth redirect and restored after callback, enabling state persistence through the login flow.
+- Auth state: Pinia store (`useAuthStore` from een-api-toolkit) + localStorage fallback (`een_token`, `een_tokenExpiration`).
+
+### Component Structure
+- `Home.vue` — Main layout orchestrating all panels and video player
+- `CameraSidebar.vue` — Paginated camera list with layout dropdown filter
+- `MainVideoPlayer.vue` — HD live (SDK) + HLS recorded playback with keyboard shortcuts
+- `EventsPanel.vue` / `AlertsPanel.vue` — Event/alert lists with time range, auto-refresh, live SSE
+- `EventTypesPanel.vue` — Event type toggles that filter both panels
+- `BoundingBoxOverlay.vue` — Object detection boxes on thumbnails/video
+
+### Composables (Singleton Pattern)
+Composables in `src/composables/` manage shared state as module-level singletons:
+- `useVideoExport()` — Export job lifecycle with 10-min auto-clipping
+- `useImageCache()` — LRU cache (250 items) for event thumbnails, deduplicates in-flight requests
+- `useDarkMode()` — Reactive dark mode via `dark` class on `<html>`, persisted to localStorage
+- `useHlsPlayer()` — HLS.js player setup and teardown
+
+### URL State
+All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
+
+### Dark Mode
+Toggles `dark` class on `<html>` element. Tailwind CSS scopes dark styles. Persists via localStorage (`een_dark_mode`) and sessionStorage through OAuth flow. URL param `dark=1` overrides stored preference.
+
+## Environment
+
+- **Must run on** `http://127.0.0.1:3333` (strictPort) to match OAuth redirect URI
+- **Required env vars** in `.env`: `VITE_PROXY_URL`, `VITE_EEN_CLIENT_ID`, `TEST_USER`, `TEST_PASSWORD`
+- Production build uses base path `/een-observation-app/` for GitHub Pages
+
+## Pre-commit Hook
+
+Husky pre-commit hook auto-increments patch version (`npm version patch`) when `src/`, `public/`, or `index.html` files are staged. This modifies `package.json` and stages it automatically.
+
+## Key Dependencies
+
+- `een-api-toolkit` — All EEN API calls (auth, cameras, events, alerts, media, jobs, layouts)
+- `@een/live-video-web-sdk` — Live HD video streaming
+- `hls.js` — HLS recorded video playback
+- `pinia` — State management (auth store from toolkit + app state)
+- `tailwindcss` v4 — Styling with PostCSS plugin (`@tailwindcss/postcss`)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A Vue 3 single-page application for Eagle Eye Networks camera monitoring with li
   - `Space` — Toggle play/pause
   - `Left Arrow` — Skip backward 10 seconds
   - `Right Arrow` — Skip forward 10 seconds
+  - `Shift + Left Arrow` — Skip backward 0.5 seconds
+  - `Shift + Right Arrow` — Skip forward 0.5 seconds
   - `Enter` — Seek to event timestamp and pause
 - **Auto-Retry Offline Cameras** - Cameras that are offline are automatically re-checked every 60 seconds; live stream and sidebar previews recover when the camera comes back online
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.35",
+  "version": "1.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.35",
+      "version": "1.0.37",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/een-api-toolkit": {
-      "version": "0.3.63",
-      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.63.tgz",
-      "integrity": "sha512-HefaeTUDamPZjR8CxQyTj9Wg/FIN/bzQMQLVc253or9KCVa11MYs3k0wXc501HFWqz6ZxVM9wjDvf0Pngcf4gg==",
+      "version": "0.3.67",
+      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.67.tgz",
+      "integrity": "sha512-yMZbKo0eNhj7dO2CeT24mEgoZMX8m12OI3Fi193dCu/8fpscpfJ42fhW7J1yN9FlrPE2A+NAXtYDyYIZjTl01Q==",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -158,11 +158,11 @@ function handlePlaybackKeys(event: KeyboardEvent) {
       break
     case 'ArrowRight':
       event.preventDefault()
-      video.currentTime = Math.min(video.currentTime + 10, video.duration)
+      video.currentTime = Math.min(video.currentTime + (event.shiftKey ? 0.5 : 10), video.duration)
       break
     case 'ArrowLeft':
       event.preventDefault()
-      video.currentTime = Math.max(video.currentTime - 10, 0)
+      video.currentTime = Math.max(video.currentTime - (event.shiftKey ? 0.5 : 10), 0)
       break
     case 'Enter':
       event.preventDefault()


### PR DESCRIPTION
## Summary
- Add fine-grained 0.5-second seeking with Shift+Left/Right arrow keys during recorded video playback
- Update een-api-toolkit from 0.3.63 to 0.3.67
- Add CLAUDE.md for Claude Code guidance

## Test plan
- [x] All 38 E2E tests passing
- [ ] Verify Shift+Left Arrow skips back 0.5s in recorded playback
- [ ] Verify Shift+Right Arrow skips forward 0.5s in recorded playback
- [ ] Verify plain Arrow keys still skip 10s as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)