### PR TITLE
Add sound notifications on SSE events with mute toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Vue 3 single-page application for Eagle Eye Networks camera monitoring. Uses the
 |---------|-------------|
 | `npm run dev` | Start dev server at `http://127.0.0.1:3333` (kills existing port 3333 process first) |
 | `npm run build` | Type-check with `vue-tsc --noEmit` then build with Vite |
-| `npm test` | Run all 38 Playwright E2E tests (requires dev server + OAuth proxy) |
+| `npm test` | Run all 41 Playwright E2E tests (requires dev server + OAuth proxy) |
 | `npx playwright test tests/events.spec.ts` | Run a single test file |
 | `npx playwright test -g "should toggle dark mode"` | Run a single test by name |
 | `npx playwright test --ui` | Interactive Playwright UI |
@@ -49,7 +49,7 @@ Composables in `src/composables/` manage shared state as module-level singletons
 - `useHlsPlayer()` — HLS.js player setup and teardown
 
 ### URL State
-All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
+All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`, `mute`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
 
 ### Dark Mode
 Toggles `dark` class on `<html>` element. Tailwind CSS scopes dark styles. Persists via localStorage (`een_dark_mode`) and sessionStorage through OAuth flow. URL param `dark=1` overrides stored preference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ Composables in `src/composables/` manage shared state as module-level singletons
 - `useVideoExport()` — Export job lifecycle with 10-min auto-clipping
 - `useImageCache()` — LRU cache (250 items) for event thumbnails, deduplicates in-flight requests
 - `useDarkMode()` — Reactive dark mode via `dark` class on `<html>`, persisted to localStorage
+- `useMute()` — Mute toggle persisted to localStorage, with sessionStorage through OAuth flow
+- `useSseNotification()` — SSE event notification banner with Web Audio API beep sound
 - `useHlsPlayer()` — HLS.js player setup and teardown
 
 ### URL State

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The bottom section of the application contains three panels for event management
 
 ### User Interface
 - **Dark Mode Toggle** - Switch between light and dark themes with persistent preference
+- **Sound Notifications** - Audio beep on new SSE events; mute toggle in the top bar with URL parameter persistence
 - **Event/Alert Highlighting** - Active event or alert shows orange border
 - **Visual Camera Selection Feedback** - Selected camera shows thick border
 - **Panel Tooltips** - Hover over panel titles to see descriptions
@@ -111,17 +112,17 @@ The bottom section of the application contains three panels for event management
 
 ## URL Parameters
 
-The application supports deep-linking with URL parameters to restore camera selection, selected camera, event type filters, time range durations, auto-refresh settings, live events toggle, event filter, and dark mode.
+The application supports deep-linking with URL parameters to restore camera selection, selected camera, event type filters, time range durations, auto-refresh settings, live events toggle, event filter, dark mode, and mute state.
 
 ### Full URL Format
 
 ```
-http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>&ed=<duration>&ad=<duration>&er=1&ar=1&live=1&filter=1&dark=1
+http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>&ed=<duration>&ad=<duration>&er=1&ar=1&live=1&filter=1&dark=1&mute=1
 ```
 
 **Example:**
 ```
-http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj&ed=24h&ad=1w&er=1&live=1&dark=1
+http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj&ed=24h&ad=1w&er=1&live=1&dark=1&mute=1
 ```
 
 ### Parameters
@@ -138,6 +139,7 @@ http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nk
 | `live` | Live events SSE feed enabled (`1` = on) | `live=1` |
 | `filter` | Event type filter for alerts enabled (`1` = on) | `filter=1` |
 | `dark` | Dark mode (`1` = on, `0` = off) | `dark=1` |
+| `mute` | Mute sound notifications (`1` = muted) | `mute=1` |
 
 ### Camera Selection (`id` and `selected`)
 
@@ -207,6 +209,13 @@ Controls the application theme:
 - `dark=0` - Enable light mode (explicit)
 
 When `dark=1` is in the URL, dark mode is enabled regardless of the user's previous preference. The parameter is only included in the URL when dark mode is enabled.
+
+### Mute (`mute`)
+
+Controls whether sound notifications are muted:
+- `mute=1` - Mute sound notifications
+
+When unmuted (default), a short audio beep plays on each new SSE event notification. The parameter is only included in the URL when muted.
 
 ### URL Persistence
 
@@ -313,7 +322,8 @@ src/
 │   ├── useEventAge.ts         # Event age formatting
 │   ├── useHlsPlayer.ts        # HLS.js player management
 │   ├── useImageCache.ts       # LRU cache for event thumbnails
-│   ├── useSseNotification.ts  # Toast notifications for SSE events
+│   ├── useMute.ts             # Mute toggle with localStorage persistence
+│   ├── useSseNotification.ts  # Toast notifications for SSE events with sound
 │   └── useVideoExport.ts      # Video export with auto-clipping
 ├── views/
 │   ├── Home.vue               # Main application view
@@ -335,6 +345,7 @@ tests/
 ├── auth.spec.ts               # Authentication and user info modal tests (8)
 ├── cameras.spec.ts            # Camera sidebar, selection, and info tests (11)
 ├── dark-mode.spec.ts          # Dark mode toggle and URL parameter tests (2)
+├── mute.spec.ts               # Mute toggle, URL parameter, and persistence tests (3)
 ├── event-types.spec.ts        # Event type selection and count tests (3)
 ├── events.spec.ts             # Events and alerts panel tests (10)
 ├── url-state.spec.ts          # URL parameter state persistence tests (1)
@@ -343,7 +354,7 @@ tests/
 
 ## Testing
 
-The project includes 38 Playwright E2E tests across 7 spec files:
+The project includes 41 Playwright E2E tests across 8 spec files:
 
 ### Authentication (`auth.spec.ts` — 8 tests)
 - Redirect unauthenticated users to login page
@@ -369,6 +380,11 @@ The project includes 38 Playwright E2E tests across 7 spec files:
 ### Dark Mode (`dark-mode.spec.ts` — 2 tests)
 - Toggle dark mode on/off and verify `dark` class on `<html>`
 - Dark mode URL parameter persistence through OAuth login flow
+
+### Mute (`mute.spec.ts` — 3 tests)
+- Toggle mute on/off and verify icon/title changes
+- Mute URL parameter (`mute=1`) appears when muted, removed when unmuted
+- Mute state persists through OAuth login flow via sessionStorage
 
 ### Event Types (`event-types.spec.ts` — 3 tests)
 - Toggle individual event types on/off with URL `events` parameter update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch, provide, onUnmounted } from 'vue'
 import { useAuthStore, getCurrentUser } from 'een-api-toolkit'
 import { useRoute } from 'vue-router'
 import { useDarkMode } from '@/composables/useDarkMode'
+import { useMute } from '@/composables/useMute'
 import { useVideoExport } from '@/composables/useVideoExport'
 import { useSseNotification } from '@/composables/useSseNotification'
 import ExportStatusModal from '@/components/ExportStatusModal.vue'
@@ -23,6 +24,9 @@ const route = useRoute()
 // Dark mode
 const { isDark, toggle: toggleDarkMode, setDark } = useDarkMode()
 
+// Mute
+const { isMuted, toggle: toggleMute, setMuted } = useMute()
+
 // Video export state
 const { status: exportStatus, progressPercent: exportProgress, isActive: exportIsActive } = useVideoExport()
 const showExportModal = ref(false)
@@ -30,8 +34,9 @@ const showExportModal = ref(false)
 // SSE notification state
 const { notification: sseNotification } = useSseNotification()
 
-// Provide dark mode state to child components
+// Provide dark mode and mute state to child components
 provide('isDark', isDark)
+provide('isMuted', isMuted)
 
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 
@@ -133,6 +138,14 @@ onMounted(() => {
   } else if (urlDark === '0') {
     setDark(false)
   }
+
+  // Check for mute URL parameter (overrides localStorage)
+  const urlMute = sessionStorage.getItem('een_url_mute')
+  if (urlMute === '1') {
+    setMuted(true)
+  } else if (urlMute === '0') {
+    setMuted(false)
+  }
 })
 
 onUnmounted(() => {
@@ -215,19 +228,36 @@ watch(() => authStore.isAuthenticated, loadUser)
             </span>
           </button>
 
+          <!-- Mute Toggle -->
+          <button
+            @click="toggleMute"
+            class="p-1.5 rounded-lg hover:bg-white/10 transition-colors"
+            :title="isMuted ? 'Sound is muted' : 'Sound is on'"
+          >
+            <!-- Speaker icon (shown when unmuted) -->
+            <svg v-if="!isMuted" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072M17.95 6.05a8 8 0 010 11.9M11 5L6 9H2v6h4l5 4V5z" />
+            </svg>
+            <!-- Muted speaker icon (shown when muted) -->
+            <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2" />
+            </svg>
+          </button>
+
           <!-- Dark Mode Toggle -->
           <button
             @click="toggleDarkMode"
             class="p-1.5 rounded-lg hover:bg-white/10 transition-colors"
             :title="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
           >
-            <!-- Sun icon (shown in dark mode) -->
+            <!-- Moon icon (shown in dark mode - indicates current state) -->
             <svg v-if="isDark" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-            <!-- Moon icon (shown in light mode) -->
-            <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+            </svg>
+            <!-- Sun icon (shown in light mode - indicates current state) -->
+            <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
             </svg>
           </button>
 

--- a/src/composables/useMute.ts
+++ b/src/composables/useMute.ts
@@ -1,0 +1,31 @@
+import { ref, watch } from 'vue'
+
+// Mute state - persisted in localStorage
+const isMuted = ref(false)
+
+// Initialize from localStorage
+const stored = localStorage.getItem('een_mute')
+if (stored !== null) {
+  isMuted.value = stored === 'true'
+}
+
+// Watch for changes and persist
+watch(isMuted, (value) => {
+  localStorage.setItem('een_mute', String(value))
+})
+
+export function useMute() {
+  function toggle() {
+    isMuted.value = !isMuted.value
+  }
+
+  function setMuted(value: boolean) {
+    isMuted.value = value
+  }
+
+  return {
+    isMuted,
+    toggle,
+    setMuted
+  }
+}

--- a/src/composables/useSseNotification.ts
+++ b/src/composables/useSseNotification.ts
@@ -1,4 +1,5 @@
 import { ref, computed } from 'vue'
+import { useMute } from './useMute'
 
 // Shared state for SSE event notification
 const notificationMessage = ref<string | null>(null)
@@ -11,7 +12,32 @@ let fadeTimeout: ReturnType<typeof setTimeout> | null = null
 const DISPLAY_DURATION = 1000 // 1 second display
 const FADE_DURATION = 1000 // 1 second fade
 
+// Play a short notification beep using Web Audio API
+let audioContext: AudioContext | null = null
+
+function playNotificationSound() {
+  try {
+    if (!audioContext) {
+      audioContext = new AudioContext()
+    }
+    const oscillator = audioContext.createOscillator()
+    const gainNode = audioContext.createGain()
+    oscillator.connect(gainNode)
+    gainNode.connect(audioContext.destination)
+    oscillator.frequency.value = 880
+    oscillator.type = 'sine'
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime)
+    gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.2)
+    oscillator.start(audioContext.currentTime)
+    oscillator.stop(audioContext.currentTime + 0.2)
+  } catch {
+    // Ignore audio errors (e.g., autoplay policy)
+  }
+}
+
 export function useSseNotification() {
+  const { isMuted } = useMute()
+
   // Show notification with event type name
   function showNotification(eventTypeName: string) {
     // Clear any existing timeouts
@@ -22,6 +48,11 @@ export function useSseNotification() {
     if (fadeTimeout) {
       clearTimeout(fadeTimeout)
       fadeTimeout = null
+    }
+
+    // Play notification sound if not muted
+    if (!isMuted.value) {
+      playNotificationSound()
     }
 
     // Set the message and show immediately (reset fade state)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -88,6 +88,7 @@ router.beforeEach((to, _from, next) => {
       sessionStorage.removeItem('een_url_live')
       sessionStorage.removeItem('een_url_filter')
       sessionStorage.removeItem('een_url_dark')
+      sessionStorage.removeItem('een_url_mute')
     }
 
     if (to.query.id) {
@@ -159,6 +160,13 @@ router.beforeEach((to, _from, next) => {
       sessionStorage.setItem('een_url_dark', to.query.dark as string)
     } else {
       sessionStorage.removeItem('een_url_dark')
+    }
+
+    // Store mute (mute)
+    if (to.query.mute !== undefined) {
+      sessionStorage.setItem('een_url_mute', to.query.mute as string)
+    } else {
+      sessionStorage.removeItem('een_url_mute')
     }
   }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,8 +12,9 @@ import AlertsPanel from '../components/AlertsPanel.vue'
 import type { BoundingBox } from '@/composables/useBoundingBoxes'
 import { eventTypesToHashString } from '@/utils/eventTypeHash'
 
-// Inject dark mode state
+// Inject dark mode and mute state
 const isDark = inject<Ref<boolean>>('isDark', ref(false))
+const isMuted = inject<Ref<boolean>>('isMuted', ref(false))
 
 interface UserProfile {
   id: string
@@ -241,6 +242,11 @@ function updateUrl() {
     newQuery.dark = '1'
   }
 
+  // Add mute parameter (only if muted)
+  if (isMuted.value) {
+    newQuery.mute = '1'
+  }
+
   // Only update if different to avoid unnecessary history entries
   const currentId = route.query.id as string | undefined
   const currentSelected = route.query.selected as string | undefined
@@ -252,7 +258,8 @@ function updateUrl() {
   const currentLive = route.query.live as string | undefined
   const currentFilter = route.query.filter as string | undefined
   const currentDark = route.query.dark as string | undefined
-  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events || currentEd !== newQuery.ed || currentAd !== newQuery.ad || currentEr !== newQuery.er || currentAr !== newQuery.ar || currentLive !== newQuery.live || currentFilter !== newQuery.filter || currentDark !== newQuery.dark) {
+  const currentMute = route.query.mute as string | undefined
+  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events || currentEd !== newQuery.ed || currentAd !== newQuery.ad || currentEr !== newQuery.er || currentAr !== newQuery.ar || currentLive !== newQuery.live || currentFilter !== newQuery.filter || currentDark !== newQuery.dark || currentMute !== newQuery.mute) {
     router.replace({ query: newQuery })
   }
 }
@@ -412,8 +419,12 @@ onMounted(async () => {
   loading.value = false
 })
 
-// Watch for dark mode changes and update URL
+// Watch for dark mode and mute changes and update URL
 watch(isDark, () => {
+  updateUrl()
+})
+
+watch(isMuted, () => {
   updateUrl()
 })
 </script>

--- a/tests/mute.spec.ts
+++ b/tests/mute.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect, Page } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * E2E tests for Mute Toggle
+ *
+ * Tests:
+ * 1. Toggle mute and verify icon/title changes
+ * 2. Verify mute=1 URL parameter appears/disappears
+ * 3. Verify mute persists through login flow via sessionStorage
+ */
+
+const TIMEOUTS = {
+  OAUTH_REDIRECT: 30000,
+  ELEMENT_VISIBLE: 15000,
+  PASSWORD_VISIBLE: 10000,
+  AUTH_COMPLETE: 60000,
+  UI_UPDATE: 10000,
+  PROXY_CHECK: 5000
+} as const
+
+const TEST_USER = process.env.TEST_USER
+const TEST_PASSWORD = process.env.TEST_PASSWORD
+const PROXY_URL = process.env.VITE_PROXY_URL
+
+async function isProxyAccessible(): Promise<boolean> {
+  if (!PROXY_URL) return false
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.PROXY_CHECK)
+
+  try {
+    const response = await fetch(PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    return response.ok || response.status === 404
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function performLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login')
+  await page.click('button:has-text("Login with Eagle Eye Networks")')
+
+  await Promise.race([
+    page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: TIMEOUTS.OAUTH_REDIRECT }),
+    page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.OAUTH_REDIRECT })
+  ])
+
+  const currentUrl = page.url()
+  if (/(?:^|\.)eagleeyenetworks\.com$/.test(new URL(currentUrl).hostname)) {
+    const emailInput = page.locator('#authentication--input__email, input[type="email"], input[type="text"]').first()
+    await emailInput.waitFor({ state: 'visible', timeout: TIMEOUTS.ELEMENT_VISIBLE })
+    await emailInput.fill(username)
+    await page.getByRole('button', { name: 'Next' }).click()
+
+    const passwordInput = page.locator('#authentication--input__password, input[type="password"]')
+    await passwordInput.waitFor({ state: 'visible', timeout: TIMEOUTS.PASSWORD_VISIBLE })
+    await passwordInput.fill(password)
+    await page.locator('#next, button:has-text("Sign in")').first().click()
+
+    await page.waitForURL(/127\.0\.0\.1:3333/, { timeout: TIMEOUTS.AUTH_COMPLETE })
+  }
+
+  await page.waitForFunction(
+    () => window.location.pathname === '/' && !window.location.search.includes('code='),
+    { timeout: TIMEOUTS.AUTH_COMPLETE }
+  )
+}
+
+async function clearAuthState(page: Page): Promise<void> {
+  try {
+    const url = page.url()
+    if (url && url.startsWith('http')) {
+      await page.evaluate(() => {
+        try {
+          localStorage.clear()
+          sessionStorage.clear()
+        } catch {
+          // Ignore
+        }
+      })
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+test.describe('Mute Toggle', () => {
+  let proxyAccessible = false
+
+  function skipIfNoProxy() {
+    test.skip(!proxyAccessible, 'OAuth proxy not accessible')
+  }
+
+  function skipIfNoCredentials() {
+    test.skip(!TEST_USER || !TEST_PASSWORD, 'Test credentials not available')
+  }
+
+  test.beforeAll(async () => {
+    proxyAccessible = await isProxyAccessible()
+    if (!proxyAccessible) {
+      console.log('OAuth proxy not accessible - mute tests will be skipped')
+    }
+  })
+
+  test.afterEach(async ({ page }) => {
+    await clearAuthState(page)
+  })
+
+  test('should toggle mute and verify icon/title changes', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+
+    // Wait for app to load
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Find the mute toggle button (initially unmuted)
+    const muteToggle = page.locator('button[title="Sound is on"], button[title="Sound is muted"]')
+    await expect(muteToggle).toBeVisible()
+
+    // Verify initial state is unmuted
+    await expect(page.locator('button[title="Sound is on"]')).toBeVisible()
+    console.log('Initial mute state: unmuted (Sound is on)')
+
+    // Click to mute
+    await muteToggle.click()
+    await page.waitForTimeout(500)
+
+    // Verify muted state
+    await expect(page.locator('button[title="Sound is muted"]')).toBeVisible()
+    console.log('Toggled to muted state')
+
+    // Click to unmute
+    await page.locator('button[title="Sound is muted"]').click()
+    await page.waitForTimeout(500)
+
+    // Verify unmuted state restored
+    await expect(page.locator('button[title="Sound is on"]')).toBeVisible()
+    console.log('Toggled back to unmuted state')
+    console.log('Mute toggle test completed successfully')
+  })
+
+  test('should add and remove mute=1 URL parameter', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Initially unmuted - URL should not contain mute=1
+    expect(page.url()).not.toContain('mute=1')
+
+    // Click to mute
+    const muteToggle = page.locator('button[title="Sound is on"]')
+    await expect(muteToggle).toBeVisible()
+    await muteToggle.click()
+    await page.waitForTimeout(500)
+
+    // Verify URL contains mute=1
+    expect(page.url()).toContain('mute=1')
+    console.log('Mute enabled, URL contains mute=1')
+
+    // Click to unmute
+    await page.locator('button[title="Sound is muted"]').click()
+    await page.waitForTimeout(500)
+
+    // Verify mute=1 removed from URL
+    expect(page.url()).not.toContain('mute=1')
+    console.log('Mute disabled, mute=1 removed from URL')
+    console.log('Mute URL parameter test completed successfully')
+  })
+
+  test('should persist mute through login flow via sessionStorage', async ({ page }) => {
+    skipIfNoProxy()
+    skipIfNoCredentials()
+
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Enable mute
+    const muteToggle = page.locator('button[title="Sound is on"]')
+    await expect(muteToggle).toBeVisible()
+    await muteToggle.click()
+    await page.waitForTimeout(500)
+
+    // Verify URL contains mute=1
+    expect(page.url()).toContain('mute=1')
+    const muteUrl = page.url()
+
+    // Logout
+    await page.getByRole('link', { name: /logout/i }).click()
+    await expect(page.getByRole('heading', { name: /logged out/i })).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Clear auth state but preserve sessionStorage for mute
+    await page.evaluate(() => {
+      try { localStorage.clear() } catch { /* ignore */ }
+    })
+
+    // Navigate to the mute URL (triggers sessionStorage save via router guard)
+    await page.goto(muteUrl)
+    await expect(page).toHaveURL('/login')
+
+    // Login again - mute should be restored from sessionStorage
+    await performLogin(page, TEST_USER!, TEST_PASSWORD!)
+    await expect(page.locator('.camera-sidebar')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+
+    // Verify mute is active (restored from URL parameter via sessionStorage)
+    await expect(page.locator('button[title="Sound is muted"]')).toBeVisible({ timeout: TIMEOUTS.UI_UPDATE })
+    console.log('Mute restored via URL parameter through login flow')
+
+    console.log('Mute sessionStorage persistence test completed successfully')
+  })
+})


### PR DESCRIPTION
## Summary
- Play a Web Audio API beep (880Hz, 200ms) when new SSE event notifications appear in the top bar
- Add mute toggle button (speaker/muted icon) to the left of the dark mode toggle with localStorage persistence
- Add `mute` URL parameter (`mute=1` = muted) with sessionStorage persistence through OAuth flow
- Swap dark mode icons to show current state (moon when dark, sun when light)
- 3 new E2E tests for mute toggle, URL parameter, and sessionStorage persistence (41 total)

Closes #45

## Test plan
- [x] `npm run build` passes type-check and production build
- [x] All 41 E2E tests pass (`npm test`)
- [ ] Manual: toggle mute, hear beep on SSE event when unmuted, no sound when muted
- [ ] Manual: verify dark mode shows moon icon in dark, sun icon in light
- [ ] Manual: verify `mute=1` appears/disappears in URL when toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)