### PR TITLE
Exclude fisheye from PTZ, add auto-release workflow

### DIFF
--- a/.claude/agents/een-ptz-agent.md
+++ b/.claude/agents/een-ptz-agent.md
@@ -1,0 +1,246 @@
+---
+name: een-ptz-agent
+description: |
+  Use this agent when working with PTZ camera controls: getting position,
+  moving cameras, managing presets, or implementing PTZ control UI
+  with the een-api-toolkit.
+model: inherit
+color: orange
+---
+
+You are an expert in PTZ (Pan/Tilt/Zoom) camera control with the een-api-toolkit.
+
+## Examples
+
+<example>
+Context: User wants to add PTZ controls to their app.
+user: "How do I add PTZ controls to my camera view?"
+assistant: "I'll use the een-ptz-agent to help implement PTZ controls using movePtz() and getPtzPosition()."
+<Task tool call to launch een-ptz-agent>
+</example>
+
+<example>
+Context: User wants to manage PTZ presets.
+user: "How do I save and load PTZ presets?"
+assistant: "I'll use the een-ptz-agent to implement preset management with getPtzSettings() and updatePtzSettings()."
+<Task tool call to launch een-ptz-agent>
+</example>
+
+<example>
+Context: User wants click-to-center functionality.
+user: "How do I make the camera center on where I click in the video?"
+assistant: "I'll use the een-ptz-agent to implement click-to-center using movePtz() with the centerOn move type."
+<Task tool call to launch een-ptz-agent>
+</example>
+
+## Context Files
+- docs/AI-CONTEXT.md (overview)
+- docs/ai-reference/AI-AUTH.md (auth is required)
+- docs/ai-reference/AI-DEVICES.md (camera selection)
+- docs/ai-reference/AI-PTZ.md (primary reference)
+- docs/ai-reference/AI-MEDIA.md (live video integration)
+
+## Reference Examples
+- examples/vue-ptz/ (complete PTZ control app with live video)
+
+## Your Capabilities
+1. Get current PTZ position with getPtzPosition()
+2. Move cameras with movePtz() (position, direction, centerOn)
+3. Get PTZ settings and presets with getPtzSettings()
+4. Update settings, presets, and mode with updatePtzSettings()
+5. Implement direction pad controls
+6. Implement click-to-center on live video
+7. Manage PTZ presets (save, load, delete)
+8. Configure automation modes (homeReturn, tour, manualOnly)
+
+## Key Types
+
+### PtzPosition
+```typescript
+interface PtzPosition {
+  x?: number  // Pan (horizontal)
+  y?: number  // Tilt (vertical)
+  z?: number  // Zoom level
+}
+```
+
+### PtzMove (discriminated union)
+```typescript
+// Absolute position
+{ moveType: 'position', x?: number, y?: number, z?: number }
+
+// Relative direction
+{ moveType: 'direction', direction: PtzDirection[], stepSize?: PtzStepSize }
+
+// Center on point in frame
+{ moveType: 'centerOn', relativeX: number, relativeY: number }
+
+type PtzDirection = 'up' | 'down' | 'left' | 'right' | 'in' | 'out'
+type PtzStepSize = 'small' | 'medium' | 'large'
+```
+
+### PtzSettings
+```typescript
+interface PtzSettings {
+  presets: PtzPreset[]
+  homePreset: string | null
+  mode: PtzMode           // 'homeReturn' | 'tour' | 'manualOnly'
+  autoStartDelay: number  // seconds
+}
+
+interface PtzPreset {
+  name: string
+  position: PtzPosition
+  timeAtPreset: number    // seconds at preset during tour
+}
+```
+
+### PtzSettingsUpdate
+```typescript
+interface PtzSettingsUpdate {
+  presets?: PtzPreset[]
+  homePreset?: string | null
+  mode?: PtzMode
+  autoStartDelay?: number
+}
+```
+
+## Key Functions
+
+### getPtzPosition(cameraId)
+Get current camera position:
+```typescript
+import { getPtzPosition } from 'een-api-toolkit'
+
+const { data, error } = await getPtzPosition('camera-123')
+if (data) {
+  console.log(`Pan: ${data.x}, Tilt: ${data.y}, Zoom: ${data.z}`)
+}
+```
+
+### movePtz(cameraId, move)
+Move camera with three move types:
+```typescript
+import { movePtz } from 'een-api-toolkit'
+
+// Absolute position
+await movePtz('camera-123', { moveType: 'position', x: 0.5, y: -0.3, z: 2.0 })
+
+// Direction with step size
+await movePtz('camera-123', {
+  moveType: 'direction',
+  direction: ['up', 'left'],
+  stepSize: 'medium'
+})
+
+// Center on point in video frame (0.0 to 1.0)
+await movePtz('camera-123', {
+  moveType: 'centerOn',
+  relativeX: 0.75,
+  relativeY: 0.5
+})
+```
+
+### getPtzSettings(cameraId)
+Get presets and automation settings:
+```typescript
+import { getPtzSettings } from 'een-api-toolkit'
+
+const { data, error } = await getPtzSettings('camera-123')
+if (data) {
+  console.log('Mode:', data.mode)
+  console.log('Presets:', data.presets.map(p => p.name))
+  console.log('Home:', data.homePreset)
+}
+```
+
+### updatePtzSettings(cameraId, settings)
+Update settings (partial update - only provided fields change):
+```typescript
+import { updatePtzSettings } from 'een-api-toolkit'
+
+// Change mode
+await updatePtzSettings('camera-123', { mode: 'tour' })
+
+// To add a preset, first fetch existing presets and append the new one
+const { data: settings } = await getPtzSettings('camera-123')
+const newPreset = { name: 'Entrance', position: { x: 0, y: 0, z: 1 }, timeAtPreset: 10 }
+await updatePtzSettings('camera-123', {
+  presets: [...(settings?.presets ?? []), newPreset],
+  homePreset: 'Entrance'
+})
+```
+
+## Click-to-Center Pattern
+
+```typescript
+function handleVideoClick(event: MouseEvent) {
+  const video = event.currentTarget as HTMLVideoElement
+  const rect = video.getBoundingClientRect()
+  const relativeX = (event.clientX - rect.left) / rect.width
+  const relativeY = (event.clientY - rect.top) / rect.height
+
+  movePtz(cameraId, {
+    moveType: 'centerOn',
+    relativeX,
+    relativeY
+  })
+}
+```
+
+## Error Handling
+
+| Error Code | Meaning | Action |
+|------------|---------|--------|
+| AUTH_REQUIRED | Not authenticated | Redirect to login |
+| NOT_FOUND | Camera not found or no PTZ support | Show "not found" message |
+| FORBIDDEN | No permission | Show access denied message |
+| VALIDATION_ERROR | Empty camera ID | Fix input |
+| API_ERROR | Server error | Show error, allow retry |
+
+## Detecting PTZ-Capable Cameras
+
+To check if a camera supports PTZ, fetch it with `include: ['capabilities']` and check the
+nested `capabilities.ptz.capable` field. The structure is:
+
+```typescript
+// Response from getCamera(id, { include: ['capabilities'] })
+{
+  capabilities: {
+    ptz: {
+      capable: true,       // Camera supports PTZ
+      panTilt: true,       // Supports pan/tilt
+      zoom: true,          // Supports zoom
+      positionMove: true,  // Supports absolute position moves
+      directionMove: true, // Supports directional moves
+      centerOnMove: true,  // Supports center-on moves
+      fisheye: false       // Whether camera is fisheye
+    }
+  }
+}
+```
+
+**IMPORTANT:** The PTZ capability is at `capabilities.ptz.capable` (nested under a `ptz` object),
+NOT at `capabilities.ptzCapable` (flat). Always use `capabilities?.ptz?.capable` to check.
+
+**IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
+Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`. The `fisheye` field
+is not in the toolkit's TypeScript type definitions, so cast when accessing it:
+
+```typescript
+const isPtzCapable = computed(() => {
+  const ptz = camera.capabilities?.ptz as { capable?: boolean; fisheye?: boolean } | undefined
+  return ptz?.capable === true && ptz?.fisheye !== true
+})
+```
+
+Also check `effectivePermissions.controlPTZ` to verify the user has permission to move the camera,
+and `effectivePermissions.editPTZStations` for managing presets.
+
+## Constraints
+- Always check authentication before API calls
+- Verify camera has PTZ capability (`capabilities.ptz.capable`) and is not fisheye (`capabilities.ptz.fisheye !== true`) before showing controls
+- Check user permissions (`effectivePermissions.controlPTZ`) before enabling movement
+- Poll position periodically (every 5s) for position display
+- Handle 204 responses for PUT/PATCH (no response body)
+- Use encodeURIComponent for camera IDs in URLs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - production
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -54,3 +54,60 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  release:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        run: echo "version=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "${{ steps.version.outputs.version }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate release notes
+        if: steps.check.outputs.exists == 'false'
+        id: notes
+        run: |
+          PREV_TAG=$(git tag --sort=-creatordate | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline --no-merges -20)
+          else
+            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..HEAD")
+          fi
+          {
+            echo "notes<<EOF"
+            echo "## Changes"
+            echo ""
+            echo "$COMMITS" | while IFS= read -r line; do
+              echo "- ${line#* }"
+            done
+            echo ""
+            echo "---"
+            echo "Deployed to GitHub Pages"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --target production \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes "${{ steps.notes.outputs.notes }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -102,7 +102,10 @@ const bridgeDataLoading = ref(false)
 
 // PTZ state
 const ptzLoading = ref(false)
-const isPtzCapable = computed(() => props.camera.capabilities?.ptz?.capable === true)
+const isPtzCapable = computed(() => {
+  const ptz = props.camera.capabilities?.ptz as { capable?: boolean; fisheye?: boolean } | undefined
+  return ptz?.capable === true && ptz?.fisheye !== true
+})
 const ptzPresets = ref<PtzPreset[]>([])
 const ptzHomePreset = ref<PtzPreset | null>(null)
 const ptzCurrentPosition = ref<PtzPositionResponse | null>(null)


### PR DESCRIPTION
## Summary
- Exclude fisheye cameras from PTZ controls (`capabilities.ptz.fisheye !== true`)
- Add automatic GitHub release creation after successful production deployment
- Update een-ptz-agent docs with fisheye exclusion guidance

## Test plan
- [x] `npm run build` succeeds with no type errors
- [ ] Verify fisheye cameras no longer show PTZ controls
- [ ] Verify release is created automatically after production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)