### PR TITLE
Fix camera selection review issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Vue 3 single-page application for Eagle Eye Networks camera monitoring. Uses the
 |---------|-------------|
 | `npm run dev` | Start dev server at `http://127.0.0.1:3333` (kills existing port 3333 process first) |
 | `npm run build` | Type-check with `vue-tsc --noEmit` then build with Vite |
-| `npm test` | Run all 41 Playwright E2E tests (requires dev server + OAuth proxy) |
+| `npm test` | Run all 45 Playwright E2E tests (requires dev server + OAuth proxy) |
 | `npx playwright test tests/events.spec.ts` | Run a single test file |
 | `npx playwright test -g "should toggle dark mode"` | Run a single test by name |
 | `npx playwright test --ui` | Interactive Playwright UI |
@@ -36,6 +36,7 @@ Vue 3 single-page application for Eagle Eye Networks camera monitoring. Uses the
 ### Component Structure
 - `Home.vue` — Main layout orchestrating all panels and video player
 - `CameraSidebar.vue` — Paginated camera list with layout dropdown filter
+- `CameraSelectModal.vue` — Camera selection modal (up to 10 cameras)
 - `MainVideoPlayer.vue` — HD live (SDK) + HLS recorded playback with keyboard shortcuts
 - `EventsPanel.vue` / `AlertsPanel.vue` — Event/alert lists with time range, auto-refresh, live SSE
 - `EventTypesPanel.vue` — Event type toggles that filter both panels

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -500,7 +500,7 @@ onUnmounted(() => {
     <CameraSelectModal
       :show="showCameraSelectModal"
       :all-cameras="allCameras"
-      :current-url-camera-ids="selectedLayoutId === 'url' ? urlCameraIds : cameras.map(c => c.id)"
+      :current-url-camera-ids="selectedLayoutId === 'url' ? urlCameraIds.filter(id => allCameras.some(c => c.id === id)) : cameras.slice(0, 10).map(c => c.id)"
       @close="showCameraSelectModal = false"
       @confirm="handleCameraSelectionConfirm"
     />

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -269,8 +269,7 @@ async function refresh() {
 // Handle camera selection modal confirm
 function handleCameraSelectionConfirm(selectedIds: string[]) {
   showCameraSelectModal.value = false
-  const basePath = window.location.origin + import.meta.env.BASE_URL
-  const url = new URL(basePath)
+  const url = new URL(window.location.href)
   url.searchParams.set('id', selectedIds.join(','))
   window.location.href = url.toString()
 }
@@ -501,7 +500,7 @@ onUnmounted(() => {
     <CameraSelectModal
       :show="showCameraSelectModal"
       :all-cameras="allCameras"
-      :current-url-camera-ids="getVisibleCameraIds()"
+      :current-url-camera-ids="selectedLayoutId === 'url' ? urlCameraIds : cameras.map(c => c.id)"
       @close="showCameraSelectModal = false"
       @confirm="handleCameraSelectionConfirm"
     />


### PR DESCRIPTION
## Summary
- Preserve all existing URL query parameters when navigating after camera selection (fixes state loss)
- Pre-select all URL cameras in modal, not just the current pagination page (fixes silent camera drop)
- Update CLAUDE.md test count to 45 and add CameraSelectModal to component structure

## Test plan
- [ ] Open app with complex URL params (events, ed, er, dark, mute, etc.), use camera selection modal, verify all params preserved after navigation
- [ ] Set up 8+ URL cameras, open modal from page 1, verify all 8 are pre-checked
- [ ] Run E2E tests: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)