### PR TITLE
Release: Toolkit tooltip, event type docs, agent updates

### DIFF
--- a/.claude/agents/api-coverage-agent.md
+++ b/.claude/agents/api-coverage-agent.md
@@ -1,0 +1,306 @@
+---
+name: api-coverage-agent
+description: |
+  Use this agent when you need to regenerate the EEN API coverage documentation.
+  It fetches the complete EEN API v3.0 endpoint list from OpenAPI specs and the
+  developer portal, scans the toolkit codebase for implemented endpoints, and
+  produces four output documents: all endpoints, implemented endpoints, missing
+  endpoints, and an interactive HTML coverage table.
+model: sonnet
+color: cyan
+---
+
+You are an expert API documentation analyst. Your job is to produce four coverage documents comparing the full Eagle Eye Networks REST API v3.0 against what is implemented in the een-api-toolkit.
+
+## Examples
+
+<example>
+Context: User has just added new API endpoints to the toolkit.
+user: "I added camera update and delete endpoints, regenerate the coverage docs"
+assistant: "I'll use the api-coverage-agent to regenerate all four API coverage documents."
+<Task tool call to launch api-coverage-agent>
+</example>
+
+<example>
+Context: User wants to see current API coverage status.
+user: "What's our current EEN API coverage?"
+assistant: "I'll use the api-coverage-agent to produce an up-to-date coverage report."
+<Task tool call to launch api-coverage-agent>
+</example>
+
+## Output Files
+
+You produce exactly four files in `docs/`:
+
+1. **`docs/een-api-all-endpoints.md`** - Complete reference of ALL EEN API v3.0 endpoints
+2. **`docs/een-api-implemented.md`** - Endpoints implemented by the toolkit with function names and source files
+3. **`docs/een-api-missing.md`** - Endpoints not yet implemented, with coverage percentages
+4. **`docs/een-api-coverage.html`** - Interactive HTML table with filters, sorting, and summary statistics
+
+## Workflow
+
+### Phase 1: Fetch the Complete EEN API Endpoint List
+
+Fetch ALL OpenAPI specification YAML files from the EEN GitHub repository to get the authoritative endpoint list:
+
+```
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/devices_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/media_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/events_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/automations_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/grouping_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/user_and_accounts_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/system_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/account_settings_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/resellers_account_switching_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/video_search_category.yaml
+https://raw.githubusercontent.com/EENCloud/VMS-Developer-Portal/main/Open%20API%20Specifications/vehicle_surveillance_package_category.yaml
+```
+
+For each YAML file, extract ALL endpoint paths with their HTTP methods (GET, POST, PUT, PATCH, DELETE).
+
+**Important**: The OpenAPI specs may not cover every endpoint. Supplement by fetching the developer portal reference page:
+```
+https://developer.eagleeyenetworks.com/reference/using-the-api
+```
+
+Look for endpoints documented on the portal but missing from the specs. Common gaps include:
+- Events: `/events/{id}`, `/events:listRecentByType`, `/events:listFieldValues`, `/eventTypes`, `/eventMetrics`
+- Event Subscriptions: full CRUD + filters sub-resources
+- Alerts: `/alerts`, `/alerts/{id}`, `/alertTypes`
+- Notifications: `/notifications`, `/notifications/{id}`, `PATCH /notifications/{id}`
+
+### Phase 2: Scan the Toolkit for Implemented Endpoints
+
+Search the codebase for all implemented EEN API endpoints:
+
+1. **Find all API URLs**: Search for the pattern `api/v3.0` in all TypeScript files under `src/`:
+   ```
+   Grep pattern: "api/v3.0" in src/**/*.ts
+   ```
+
+2. **Find all exported async functions**: These are the public API of the toolkit:
+   ```
+   Grep pattern: "export async function" in src/**/*.ts
+   ```
+
+3. **Find all HTTP methods used**: Identify which methods (GET, POST, PATCH, DELETE, PUT) each endpoint uses:
+   ```
+   Grep pattern: "method: '(POST|PATCH|PUT|DELETE)'" in src/**/*.ts
+   ```
+   (GET is the default when no method is specified)
+
+4. **Check for SSE connections**: Look for EventSource or SSE-related code:
+   ```
+   Grep pattern: "EventSource|SSE|connectTo" in src/**/*.ts
+   ```
+
+5. **Check auth proxy functions**: These call the OAuth proxy, not EEN API directly:
+   ```
+   Read src/auth/service.ts for proxy endpoint functions
+   ```
+
+For each implemented endpoint, record:
+- HTTP method
+- EEN API path (e.g., `/api/v3.0/cameras`)
+- Toolkit function name (e.g., `getCameras()`)
+- Source file path
+
+### Phase 3: Cross-Reference and Classify
+
+For every endpoint in the complete EEN API list, determine if it is:
+- **Implemented**: A matching function exists in the toolkit (same HTTP method + path)
+- **Missing**: No implementation found
+
+Also identify:
+- Toolkit functions that call endpoints NOT in the official API docs (flag as "undocumented")
+- Auth proxy functions (not EEN API endpoints, but part of the toolkit)
+- SSE/WebSocket connections (supplementary to REST endpoints)
+
+### Phase 4: Generate the Four Documents
+
+#### Document 1: `docs/een-api-all-endpoints.md`
+
+Structure:
+```markdown
+# Eagle Eye Networks REST API v3.0 - Complete Endpoint Reference
+
+> Generated: YYYY-MM-DD
+> Source: [EEN Developer Portal](...) and [OpenAPI Specifications](...)
+
+All paths are prefixed with `/api/v3.0` on the appropriate base URL.
+
+## CATEGORY - Subcategory (N endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/path` | Description |
+...
+
+## Summary
+
+| Category | Subcategory | Endpoints |
+...
+
+### By HTTP Method
+
+| Method | Count |
+...
+```
+
+Organize endpoints by these categories and subcategories:
+- **Devices**: Cameras, Bridges, PTZ, Speakers, Device I/O, Switches, Multi Cameras, Available Devices
+- **Grouping**: Layouts, Tags, Locations, Floors, Floor Plans
+- **Media**: Media, Feeds, Exports, Jobs, Files, Downloads
+- **Events**: Events, Event Types, Event Metrics, Event Subscriptions, Alerts, Notifications
+- **Automations**: Event Alert Condition Rules, Alert Action Rules, Alert Actions
+- **Video Search**: Video Analytic Events
+- **Vehicle Surveillance**: LPR Events, LPR Alert Condition Rules, LPR Vehicle Lists
+- **User & Accounts**: Users, Accounts, Roles, Audit Log, Resource Grants, Editions
+- **Resellers**: Authorization Tokens
+- **Account Settings**: SSO, Client Settings
+- **System**: Applications, OAuth Clients, Reference Data
+
+#### Document 2: `docs/een-api-implemented.md`
+
+Structure:
+```markdown
+# een-api-toolkit - Implemented EEN API Endpoints
+
+> Generated: YYYY-MM-DD
+
+## Authentication (via OAuth Proxy)
+[Table of auth proxy functions - note these are NOT EEN API endpoints]
+
+## Category (N endpoints)
+
+| Method | EEN API Path | Toolkit Function | Source |
+|--------|-------------|-----------------|--------|
+| GET | `/api/v3.0/path` | `functionName()` | `src/.../service.ts` |
+...
+
+## Summary
+[Table with counts per category and by HTTP method]
+```
+
+#### Document 3: `docs/een-api-missing.md`
+
+Structure:
+```markdown
+# een-api-toolkit - Missing EEN API Endpoints
+
+> Generated: YYYY-MM-DD
+> Coverage: X of Y endpoints implemented (Z%)
+
+## CATEGORY - Subcategory (N of M missing)
+Implemented: [brief list of what IS implemented]
+
+| Method | Path | Description |
+...
+
+## Summary
+[Coverage table per category]
+[Lists of fully implemented sections and entirely missing sections]
+```
+
+#### Document 4: `docs/een-api-coverage.html`
+
+Generate a self-contained HTML file matching this exact visual style:
+
+**Global reset and body**:
+- `*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }`
+- Font: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, sans-serif`
+- Background: `#f5f7fa`, color: `#1a202c`
+
+**Header** (`<header>`):
+- Dark navy background: `#1a365d`, white text
+- Padding: `24px 32px`
+- `<h1>` at `1.5rem` bold: "Eagle Eye Networks API v3.0 — Toolkit Coverage"
+- `<p>` at `0.875rem`, color `#bee3f8`: generation date and source info
+
+**Container**: `max-width: 100%` (use full page width), centered, padding `24px 32px`
+
+**Stat cards** (`.stats` grid):
+- `grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))`, gap `16px`
+- Each card: white background, `border-radius: 8px`, padding `20px`, `box-shadow: 0 1px 3px rgba(0,0,0,.08)`
+- Colored `border-top: 4px solid` — blue (`#4299e1`) for Total, green (`#48bb78`) for Implemented, red (`#fc8181`) for Missing, indigo (`#667eea`) for Coverage
+- Label: `0.75rem` uppercase, `letter-spacing: .05em`, color `#718096`
+- Value: `2rem` bold, color `#2d3748`
+- Sub text: `0.8rem`, color `#718096`
+
+**Progress bar** (`.progress-wrap`):
+- White card with same shadow/radius as stat cards
+- Label row: flex with `justify-content: space-between`, `0.875rem`, color `#4a5568`
+- Bar background: `#e2e8f0`, `border-radius: 9999px`, height `12px`
+- Fill: `linear-gradient(90deg, #48bb78, #38a169)`, same radius, `transition: width .4s ease`
+
+**Filter bar** (`.filter-bar`):
+- White card, flex with `flex-wrap: wrap`, gap `12px`
+- Labels: `0.8rem`, color `#718096`
+- Inputs/selects: border `1px solid #e2e8f0`, `border-radius: 6px`, padding `6px 10px`, `0.875rem`
+- Focus: `border-color: #4299e1`, `box-shadow: 0 0 0 3px rgba(66,153,225,.15)`
+- Text input width: `220px`
+- Filter count: `margin-left: auto`, `0.8rem`, color `#718096`
+- Dropdowns: Status (All/Implemented/Missing), Category (All + each category), Method (All/GET/POST/PATCH/DELETE/PUT)
+- Text search placeholder: "path, function, description..."
+
+**Table** (`.table-wrap`):
+- White card with `overflow-x: auto` for horizontal scrollbar on narrow viewports
+- The `<table>` element must have `min-width: 1200px` so content is never clipped — the scrollbar activates instead of truncating columns
+- `<thead>`: dark background `#2d3748`, white text, uppercase `0.75rem`, `letter-spacing: .05em`
+- Headers clickable (cursor pointer) with sort icon `⇅`, changing to `▲`/`▼` when sorted
+- `<tbody>` rows: `border-bottom: 1px solid #edf2f7`, hover `#f7fafc`
+- Cell padding: `10px 14px`
+- Column classes:
+  - `.td-num`: color `#a0aec0`, `0.75rem`, width `44px`
+  - `.td-cat`: color `#4a5568`, `font-weight: 500`
+  - `.td-sub`: color `#718096`
+  - `.td-path`: monospace (`'SFMono-Regular', Consolas, monospace`), `0.8rem`, color `#2d3748`
+  - `.td-desc`: color `#4a5568`, `max-width: 280px`
+  - `.td-func`: monospace, `0.78rem`, color `#553c9a`
+
+**Badges** (`.badge`):
+- `display: inline-flex`, padding `2px 8px`, `border-radius: 4px`, `0.72rem` bold uppercase
+- Method colors: GET (`#ebf8ff`/`#2b6cb0`), POST (`#f0fff4`/`#276749`), PATCH (`#fffff0`/`#975a16`), DELETE (`#fff5f5`/`#c53030`), PUT (`#f0e6ff`/`#553c9a`)
+- Status colors: Implemented (`#f0fff4`/`#276749`), Missing (`#fff5f5`/`#c53030`)
+
+**Empty state**: centered, padding `48px`, color `#a0aec0`, with a search SVG icon
+
+**Footer**: centered, padding `24px`, color `#a0aec0`, `0.8rem`
+
+**Columns**: #, Category, Subcategory, Method, Path, Description, Status, Toolkit Function (8 columns)
+
+**JavaScript**:
+- All endpoint data in a `const endpoints = [...]` array with objects: `{cat, sub, method, path, desc, status, func}`
+- Endpoints grouped by category/subcategory with `// ─── Category - Subcategory ───` comment dividers
+- `status` values: `"impl"` for implemented, `"miss"` for missing
+- `func` is empty string for missing endpoints
+- `methodBadge(m)` and `statusBadge(s)` helper functions
+- `renderTable(data)` function to populate tbody and update filter count
+- `filterTable()` function combining all four filter inputs (status, category, method, text search across path+func+desc+sub)
+- `sortTable(colIndex)` function with toggle direction, updating header sort icons
+- `sortCol`/`sortAsc` state variables
+- Initial call to `renderTable(endpoints)` at the end
+- All code inline (no external dependencies)
+
+## Important Guidelines
+
+1. **Fetch fresh data every time** - Do not rely on cached or previously generated content. Always fetch the OpenAPI specs and scan the codebase.
+
+2. **Be accurate with counts** - Double-check endpoint totals match between documents. The total in all-endpoints.md must equal implemented + missing in missing.md.
+
+3. **Parallel fetching** - Fetch multiple OpenAPI YAML files in parallel using concurrent WebFetch calls to save time. Also run codebase Grep searches in parallel.
+
+4. **Handle OpenAPI gaps** - Some endpoints are on the developer portal but not in the OpenAPI specs (especially Events category sub-resources). Use both sources.
+
+5. **Flag undocumented endpoints** - If the toolkit implements endpoints not found in any official documentation, note them with a warning (e.g., `alertConditionRules` without the `event` prefix).
+
+6. **Include the generation date** - Use today's date in all document headers.
+
+7. **Open the HTML when done** - After writing all four files, run `open docs/een-api-coverage.html` to display the result in the browser.
+
+8. **Preserve category ordering** - Use the category order listed above consistently across all four documents.
+
+9. **Count auth proxy separately** - Auth proxy functions (getAccessToken, refreshToken, revokeToken, handleAuthCallback) communicate with the proxy server, not the EEN API. List them in the implemented doc but do not count them in the EEN API coverage totals.
+
+10. **Count SSE separately** - The `connectToEventSubscription()` function uses SSE, not REST. List it but count it separately from REST endpoint coverage.

--- a/.claude/agents/docs-accuracy-reviewer.md
+++ b/.claude/agents/docs-accuracy-reviewer.md
@@ -2,7 +2,7 @@
 name: docs-accuracy-reviewer
 description: |
   Use this agent when you need to verify that project documentation accurately reflects the actual codebase, when checking for broken links in markdown files, when validating configuration examples in documentation, or when ensuring README and other docs are up-to-date with implemented features. This agent reads documentation and compares it against source code but does not modify code files.
-model: inherit
+model: sonnet
 color: purple
 ---
 
@@ -70,6 +70,7 @@ assistant: "I'll use the docs-accuracy-reviewer agent to verify the een-* agent 
    - List all markdown files in the project (README.md, docs/**, CLAUDE.md, etc.)
    - **Scan ALL example directories** (`examples/*/README.md`) - do not skip any
    - **Check ALL agent files** in `.claude/agents/een-*.md` - verify function signatures and code examples against actual implementations
+   - **Check ALL skill files** in `.claude/skills/*/SKILL.md` - verify referenced scripts, npm commands, and workflows match actual implementations
    - Identify the source code structure for cross-referencing (especially `src/index.ts` exports, `src/*/service.ts` implementations, and `src/types/*.ts` definitions)
 
 2. **Analysis Phase**:
@@ -121,6 +122,17 @@ assistant: "I'll use the docs-accuracy-reviewer agent to verify the een-* agent 
 - Cross-reference all VITE_* variables with actual usage
 - Verify .env.example matches documentation
 - Check that all required secrets are documented
+
+### For Skills (`.claude/skills/*/SKILL.md`):
+- **Script References**: Verify all referenced scripts exist in `scripts/` and are executable
+- **npm Commands**: Verify all `npm run` commands exist in `package.json` scripts
+- **Workflow Steps**: Verify described workflows match actual tool capabilities and script behavior
+- **File Paths**: Verify all referenced file paths and directories exist
+- Cross-reference the PR-and-check skill's test commands against actual `package.json` scripts
+
+### For Test Runner Agent (`.claude/agents/test-runner.md`):
+- Verify documented test commands match `package.json` scripts (e.g., `npm run test:e2e:examples` for example app E2E tests)
+- Verify the E2E test execution approach matches the actual `scripts/run-examples-e2e.sh` behavior
 
 ### For Claude Agent Files (`.claude/agents/een-*.md`):
 - **Function Signatures**: Verify all documented function signatures match actual implementations in `src/*/service.ts`
@@ -176,9 +188,10 @@ Before completing your review:
 1. Verify you've checked ALL markdown files in the project
 2. **Confirm ALL example app READMEs were reviewed** (list them in your report)
 3. **Confirm ALL `.claude/agents/een-*.md` files were reviewed** for API accuracy
-4. Confirm each fix you made is backed by evidence from source code
-5. Re-read modified sections to ensure they're clear and accurate
-6. Check that your fixes didn't introduce new broken links or inconsistencies
+4. **Confirm ALL `.claude/skills/*/SKILL.md` files were reviewed** for script and npm command accuracy
+5. Confirm each fix you made is backed by evidence from source code
+6. Re-read modified sections to ensure they're clear and accurate
+7. Check that your fixes didn't introduce new broken links or inconsistencies
 
 ## Common Agent File Issues to Watch For
 

--- a/.claude/agents/een-ptz-agent.md
+++ b/.claude/agents/een-ptz-agent.md
@@ -221,15 +221,14 @@ nested `capabilities.ptz.capable` field. The structure is:
 ```
 
 **IMPORTANT:** The PTZ capability is at `capabilities.ptz.capable` (nested under a `ptz` object),
-NOT at `capabilities.ptzCapable` (flat). Always use `capabilities?.ptz?.capable` to check.
-
-**IMPORTANT:** Fisheye cameras report `capabilities.ptz.capable: true` but are NOT true PTZ cameras.
-Always exclude fisheye cameras by checking `capabilities.ptz.fisheye !== true`. The `fisheye` field
-is not in the toolkit's TypeScript type definitions, so cast when accessing it:
+NOT at `capabilities.ptzCapable` (flat). Fisheye cameras report `capabilities.ptz.capable: true`
+but are NOT true PTZ cameras — always exclude them. Use this pattern:
 
 ```typescript
+import { computed } from 'vue'
+
 const isPtzCapable = computed(() => {
-  const ptz = camera.capabilities?.ptz as { capable?: boolean; fisheye?: boolean } | undefined
+  const ptz = camera.value?.capabilities?.ptz
   return ptz?.capable === true && ptz?.fisheye !== true
 })
 ```

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -2,7 +2,7 @@
 name: test-runner
 description: |
   Use this agent when you need to run the complete test suite for the project, including unit tests (Vitest) and E2E tests (Playwright). This agent is ideal after writing a logical chunk of code, before creating a PR, or when you want to verify the overall health of the codebase. The agent executes tests and reports results but does not modify any code.
-model: inherit
+model: sonnet
 color: green
 ---
 
@@ -69,14 +69,16 @@ Capture and analyze:
 - Test file locations for failures
 
 ### Step 3: Execute E2E Tests
-Run the Playwright E2E test suite:
+Run the Playwright E2E tests for all example apps:
 ```bash
-npm run test:e2e
+npm run test:e2e:examples
 ```
+This script (`scripts/run-examples-e2e.sh`) discovers all example apps with `playwright.config.ts`, frees port 3333 between runs, and stops on first failure.
+
 Capture and analyze:
-- Browser contexts tested
-- Total E2E scenarios run
-- Passed/failed counts
+- Which example apps passed/failed
+- Total E2E scenarios run across all apps
+- Passed/failed counts per app
 - Screenshots or traces for failures (if available)
 - Timeout or network-related issues
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Event types are encoded as 3-character hashes to keep URLs short. The hashes use
 | 55Y | Animal Detection |
 | wOj | Device Status |
 
-See [docs/event-type-hashes.md](docs/event-type-hashes.md) for the complete list of all 60 event types and their hashes, including the hash algorithm source code.
+See [docs/event-type-hashes.md](docs/event-type-hashes.md) for the complete list of all 67 event types and their hashes, including the hash algorithm source code.
 
 ### Time Range Duration (`ed` and `ad`)
 

--- a/docs/event-type-hashes.md
+++ b/docs/event-type-hashes.md
@@ -31,19 +31,23 @@ export function hashEventType(eventType: string): string {
 
 | Hash | Event Name | Event Type |
 |------|------------|------------|
+| oxa | Access Activation | een.accessActivationEvent.v1 |
 | sMI | Account Creation | een.accountCreationEvent.v1 |
 | xDo | Account Deletion | een.accountDeletionEvent.v1 |
 | KYp | Account Update | een.accountUpdateEvent.v1 |
 | 55Y | Animal Detection | een.animalDetectionEvent.v1 |
 | 0gG | Battery Level Update | een.batteryLevelUpdateEvent.v1 |
+| ByH | Counted Object Line Cross | een.countedObjectLineCrossEvent.v1 |
 | zik | Crowd Formation Detection | een.crowdFormationDetectionEvent.v1 |
 | 3Cc | Device Creation | een.deviceCreationEvent.v1 |
 | cF7 | Device Deletion | een.deviceDeletionEvent.v1 |
 | yIm | Device I/O | een.deviceIOEvent.v1 |
 | 1pF | Device Operation | een.deviceOperationEvent.v1 |
+| SFJ | Device Cloud Connection Status | een.deviceCloudConnectionStatusUpdateEvent.v1 |
 | wOj | Device Status | een.deviceCloudStatusUpdateEvent.v1 |
 | 5Kd | Device Update | een.deviceUpdateEvent.v1 |
 | GAy | Door Status | een.doorStatusEvent.v1 |
+| 8GJ | Edge Reported Device Status | een.edgeReportedDeviceStatusEvent.v1 |
 | ztu | EEVA Event | een.eevaQueryEvent.v1 |
 | CoN | Evacuate Protocol | een.evacuateProtocolEvent.v1 |
 | qHj | Face Detection | een.faceDetectionEvent.v1 |
@@ -73,6 +77,7 @@ export function hashEventType(eventType: string): string {
 | plc | Object Removal | een.objectRemovalEvent.v1 |
 | bnl | Panic Button | een.panicButtonEvent.v1 |
 | 6pF | Person Detection | een.personDetectionEvent.v1 |
+| kdV | Person Motion Detection | een.personMotionDetectionEvent.v1 |
 | Akk | Person Tailgate Event | een.personTailgateEvent.v1 |
 | y4g | POS Transaction | een.posTransactionEvent.v1 |
 | itL | PPE Violation | een.ppeViolationEvent.v1 |
@@ -90,7 +95,9 @@ export function hashEventType(eventType: string): string {
 | Cjx | User Update | een.userUpdateEvent.v1 |
 | b99 | Vape Detection | een.vapeDetectionEvent.v1 |
 | X33 | Vehicle Detection | een.vehicleDetectionEvent.v1 |
+| jQD | Vehicle Motion Detection | een.vehicleMotionDetectionEvent.v1 |
 | Ars | Violence Detection | een.violenceDetectionEvent.v1 |
+| 97G | Weapon Detection | een.weaponDetectionEvent.v1 |
 
 ## Usage Example
 

--- a/docs/event-type-hashes.md
+++ b/docs/event-type-hashes.md
@@ -39,11 +39,11 @@ export function hashEventType(eventType: string): string {
 | 0gG | Battery Level Update | een.batteryLevelUpdateEvent.v1 |
 | ByH | Counted Object Line Cross | een.countedObjectLineCrossEvent.v1 |
 | zik | Crowd Formation Detection | een.crowdFormationDetectionEvent.v1 |
+| SFJ | Device Cloud Connection Status | een.deviceCloudConnectionStatusUpdateEvent.v1 |
 | 3Cc | Device Creation | een.deviceCreationEvent.v1 |
 | cF7 | Device Deletion | een.deviceDeletionEvent.v1 |
 | yIm | Device I/O | een.deviceIOEvent.v1 |
 | 1pF | Device Operation | een.deviceOperationEvent.v1 |
-| SFJ | Device Cloud Connection Status | een.deviceCloudConnectionStatusUpdateEvent.v1 |
 | wOj | Device Status | een.deviceCloudStatusUpdateEvent.v1 |
 | 5Kd | Device Update | een.deviceUpdateEvent.v1 |
 | GAy | Door Status | een.doorStatusEvent.v1 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,9 @@ import { useMute } from '@/composables/useMute'
 import { useVideoExport } from '@/composables/useVideoExport'
 import { useSseNotification, playNotificationSound } from '@/composables/useSseNotification'
 import ExportStatusModal from '@/components/ExportStatusModal.vue'
-import { version } from '../package.json'
+import { version, dependencies } from '../package.json'
+
+const toolkitVersion = dependencies['een-api-toolkit'].replace(/^\^|~/, '')
 
 interface UserProfile {
   id: string
@@ -188,7 +190,7 @@ watch(() => authStore.isAuthenticated, loadUser)
             <circle cx="16" cy="16" r="2.5" fill="#1e3a8a"/>
             <circle cx="14" cy="14.5" r="1.2" fill="white" opacity="0.8"/>
           </svg>
-          {{ appName }}
+          <span :title="`Powered by een-api-toolkit v${toolkitVersion}`">{{ appName }}</span>
           <span class="text-xs opacity-70 font-normal">v{{ version }}</span>
         </a>
         <div class="flex items-center gap-4 text-sm">

--- a/src/components/CameraSelectModal.vue
+++ b/src/components/CameraSelectModal.vue
@@ -88,7 +88,7 @@ function handleConfirm() {
             <h3 class="text-lg font-semibold" :class="isDark ? 'text-white' : 'text-gray-800'">
               Select Cameras
             </h3>
-            <p class="text-xs mt-0.5" :class="isDark ? 'text-gray-400' : 'text-gray-500'">
+            <p v-if="allCameras.length > MAX_CAMERAS" class="text-xs mt-0.5" :class="isDark ? 'text-gray-400' : 'text-gray-500'">
               Select up to {{ MAX_CAMERAS }} cameras
             </p>
           </div>

--- a/src/utils/eventTypeHash.ts
+++ b/src/utils/eventTypeHash.ts
@@ -1,6 +1,6 @@
 /**
  * Utility for creating short URL-safe hashes of event types.
- * Uses 3-character base62 encoding which is unique for all 60+ EEN event types.
+ * Uses 3-character base62 encoding which is unique for all 67 EEN event types.
  */
 
 const CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/tests/camera-select.spec.ts
+++ b/tests/camera-select.spec.ts
@@ -156,8 +156,9 @@ test.describe('Camera Selection Modal', () => {
     // Modal should have "Select Cameras" title
     await expect(modal.locator('h3', { hasText: 'Select Cameras' })).toBeVisible()
 
-    // Should show "Select up to 10 cameras" hint
-    await expect(modal.getByText('Select up to 10 cameras')).toBeVisible()
+    // "Select up to 10 cameras" hint only shown when more than 10 cameras
+    // Test account has 3 cameras, so verify it is NOT shown
+    await expect(modal.getByText('Select up to 10 cameras')).not.toBeVisible()
 
     // Should display camera checkboxes
     const checkboxes = modal.locator('input[type="checkbox"]')


### PR DESCRIPTION
## Summary
- Add "Powered by een-api-toolkit vX.Y.Z" tooltip on app title
- Only show "select up to 10 cameras" hint when more than 10 cameras available
- Add 7 new event types to hash documentation (67 total, all unique hashes verified)
- Install new api-coverage-agent and update ptz, test-runner, docs-accuracy-reviewer agents from toolkit v0.3.103

## Test plan
- [ ] Hover over app title, verify tooltip shows toolkit version
- [ ] Open camera selection modal with <=10 cameras, verify no limit text shown
- [ ] Run `npm run build` to verify no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)