### PR TITLE
Rename QR code URL scheme to eenobserve

### DIFF
--- a/docs/mobile-companion.md
+++ b/docs/mobile-companion.md
@@ -9,7 +9,7 @@ The Mobile Companion is a native iOS app that receives an EEN access token and c
 The web app generates a QR code encoding a custom URL scheme:
 
 ```
-eenviewer://view?token=<access_token>&cam=<camera_id>&base=<base_url>&ttl=<epoch_seconds>&events=<hash1,hash2,...>
+eenobserve://view?token=<access_token>&cam=<camera_id>&base=<base_url>&ttl=<epoch_seconds>&events=<hash1,hash2,...>
 ```
 
 - `token` — EEN OAuth access token (from `authStore.token`)
@@ -26,7 +26,7 @@ Web App                     iOS App
 1. User selects camera
 2. Clicks QR icon (auto-copies URL)
 3. QR popup shown ─────►  4. Camera scans QR
-                            5. Parse eenviewer:// URL
+                            5. Parse eenobserve:// URL
                             6. Extract token, cam, base,
                                ttl, events
                             7. Use base URL directly
@@ -41,7 +41,7 @@ Web App                     iOS App
 ## iOS App Components
 
 ### URL Scheme Handler
-- Register `eenviewer://` custom URL scheme in `Info.plist`
+- Register `eenobserve://` custom URL scheme in `Info.plist`
 - Parse `token` and `cam` query parameters
 - Store token in Keychain for the session
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -117,7 +117,7 @@ watch([() => authStore.token, selectedCameraId, selectedEvents], async ([token, 
     return
   }
   const ttl = authStore.tokenExpiration ? Math.floor(authStore.tokenExpiration / 1000) : 0
-  let url = `eenviewer://view?token=${token}&cam=${camId}&base=${encodeURIComponent(authStore.baseUrl || '')}&ttl=${ttl}`
+  let url = `eenobserve://view?token=${token}&cam=${camId}&base=${encodeURIComponent(authStore.baseUrl || '')}&ttl=${ttl}`
   if (events) url += `&events=${events}`
   if (url === qrUrl.value) return
   qrUrl.value = url


### PR DESCRIPTION
## Summary
- Renamed custom URL scheme from `eenviewer://` to `eenobserve://` in QR code generation and documentation

## Test plan
- [x] Build passes
- [ ] Verify QR code generates with `eenobserve://` scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)