### PR TITLE
Add fullscreen URL param and preview stream refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Composables in `src/composables/` manage shared state as module-level singletons
 - `useHlsPlayer()` — HLS.js player setup and teardown
 
 ### URL State
-All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`, `mute`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
+All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`, `mute`, `full`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
 
 ### Dark Mode
 Toggles `dark` class on `<html>` element. Tailwind CSS scopes dark styles. Persists via localStorage (`een_dark_mode`) and sessionStorage through OAuth flow. URL param `dark=1` overrides stored preference.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The bottom section of the application contains three panels for event management
 - **Token Auto-Refresh** - Automatic token renewal before expiration
 
 ### User Interface
-- **Fullscreen Mode** - Click the app eye icon in the top-left corner to toggle browser fullscreen; press Escape to exit
+- **Fullscreen Mode** - Click the app eye icon in the top-left corner to toggle browser fullscreen; press Escape to exit. Use `full=1` URL parameter to request fullscreen on load (shows a confirmation prompt)
 - **Help Button** - Question mark icon in the top bar opens the README documentation on GitHub
 - **Dark Mode Toggle** - Switch between light and dark themes with persistent preference
 - **Sound Notifications** - Audio beep on new SSE events; mute toggle in the top bar with URL parameter persistence
@@ -120,17 +120,17 @@ The bottom section of the application contains three panels for event management
 
 ## URL Parameters
 
-The application supports deep-linking with URL parameters to restore camera selection, selected camera, event type filters, time range durations, auto-refresh settings, live events toggle, event filter, dark mode, and mute state.
+The application supports deep-linking with URL parameters to restore camera selection, selected camera, event type filters, time range durations, auto-refresh settings, live events toggle, event filter, dark mode, mute state, and fullscreen mode.
 
 ### Full URL Format
 
 ```
-http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>&ed=<duration>&ad=<duration>&er=1&ar=1&live=1&filter=1&dark=1&mute=1
+http://127.0.0.1:3333/?id=<camera-ids>&selected=<camera-id>&events=<event-hashes>&ed=<duration>&ad=<duration>&er=1&ar=1&live=1&filter=1&dark=1&mute=1&full=1
 ```
 
 **Example:**
 ```
-http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj&ed=24h&ad=1w&er=1&live=1&dark=1&mute=1
+http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nkU,wOj&ed=24h&ad=1w&er=1&live=1&dark=1&mute=1&full=1
 ```
 
 ### Parameters
@@ -148,6 +148,7 @@ http://127.0.0.1:3333/?id=1005963a,100f030c,1003e46b&selected=100f030c&events=nk
 | `filter` | Event type filter for alerts enabled (`1` = on) | `filter=1` |
 | `dark` | Dark mode (`1` = on, `0` = off) | `dark=1` |
 | `mute` | Mute sound notifications (`1` = muted) | `mute=1` |
+| `full` | Request fullscreen mode (`1` = on) | `full=1` |
 
 ### Camera Selection (`id` and `selected`)
 
@@ -224,6 +225,13 @@ Controls whether sound notifications are muted:
 - `mute=1` - Mute sound notifications
 
 When unmuted (default), a short audio beep plays on each new SSE event notification. The parameter is only included in the URL when muted.
+
+### Fullscreen (`full`)
+
+Requests fullscreen mode on page load:
+- `full=1` - Prompt the user to enter fullscreen mode
+
+Since browsers require a real user gesture for the Fullscreen API, a confirmation dialog is shown asking the user to click "Go Fullscreen". The parameter persists through the OAuth login flow. Once in fullscreen, pressing Escape exits fullscreen and removes the parameter from the URL. Fullscreen can also be toggled manually by clicking the eye icon in the top-left corner.
 
 ### URL Persistence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.56",
+      "version": "1.0.57",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -228,6 +228,15 @@ onMounted(() => {
   // Listen for fullscreen changes
   document.addEventListener('fullscreenchange', onFullscreenChange)
 
+  // Check for fullscreen URL parameter - read from both URL and sessionStorage
+  // (sessionStorage may not be set yet if router guard hasn't run)
+  const urlParams = new URLSearchParams(window.location.search)
+  const urlFull = urlParams.get('full') || sessionStorage.getItem('een_url_full')
+  if (urlFull === '1' && !document.fullscreenElement) {
+    // Browsers require a real user gesture for fullscreen — show a prompt
+    showFullscreenPrompt.value = true
+  }
+
   // Check for mute URL parameter (overrides localStorage)
   const urlMute = sessionStorage.getItem('een_url_mute')
   if (urlMute === '1') {
@@ -249,6 +258,19 @@ watch(() => authStore.isAuthenticated, loadUser)
 
 // Fullscreen toggle
 const isFullscreen = ref(false)
+const fullscreenButtonRef = ref<HTMLButtonElement | null>(null)
+const showFullscreenPrompt = ref(false)
+
+function enterFullscreenFromPrompt() {
+  showFullscreenPrompt.value = false
+  document.documentElement.requestFullscreen().catch((err) => {
+    console.warn('[Fullscreen] requestFullscreen failed:', err)
+  })
+}
+
+function dismissFullscreenPrompt() {
+  showFullscreenPrompt.value = false
+}
 
 function toggleFullscreen() {
   if (document.fullscreenElement) {
@@ -285,6 +307,7 @@ function onFullscreenChange() {
         <div class="flex items-center gap-2 text-xl font-semibold">
           <!-- Eye icon — fullscreen toggle -->
           <button
+            ref="fullscreenButtonRef"
             @click="toggleFullscreen"
             class="hover:opacity-80 transition-opacity cursor-pointer"
             :title="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
@@ -580,6 +603,42 @@ function onFullscreenChange() {
       :show="showExportModal"
       @close="showExportModal = false"
     />
+
+    <!-- Fullscreen Prompt Overlay -->
+    <Teleport to="body">
+      <div
+        v-if="showFullscreenPrompt"
+        class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
+        @click="dismissFullscreenPrompt"
+      >
+        <div
+          class="rounded-xl shadow-2xl p-6 text-center max-w-sm mx-4"
+          :class="isDark ? 'bg-gray-800' : 'bg-white'"
+          @click.stop
+        >
+          <svg class="w-12 h-12 mx-auto mb-3 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+          </svg>
+          <p class="text-lg font-semibold mb-2" :class="isDark ? 'text-white' : 'text-gray-800'">Enter Fullscreen?</p>
+          <p class="text-sm mb-4" :class="isDark ? 'text-gray-400' : 'text-gray-500'">The URL requested fullscreen mode. Click below to activate it.</p>
+          <div class="flex gap-3 justify-center">
+            <button
+              @click="dismissFullscreenPrompt"
+              class="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+              :class="isDark ? 'bg-gray-700 text-gray-300 hover:bg-gray-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+            >
+              Cancel
+            </button>
+            <button
+              @click="enterFullscreenFromPrompt"
+              class="px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors"
+            >
+              Go Fullscreen
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -228,13 +228,14 @@ onMounted(() => {
   // Listen for fullscreen changes
   document.addEventListener('fullscreenchange', onFullscreenChange)
 
-  // Check for fullscreen URL parameter - read from both URL and sessionStorage
-  // (sessionStorage may not be set yet if router guard hasn't run)
-  const urlParams = new URLSearchParams(window.location.search)
-  const urlFull = urlParams.get('full') || sessionStorage.getItem('een_url_full')
-  if (urlFull === '1' && !document.fullscreenElement) {
-    // Browsers require a real user gesture for fullscreen — show a prompt
-    showFullscreenPrompt.value = true
+  // Check for fullscreen URL parameter - only show prompt for authenticated users
+  if (isAuthenticated.value) {
+    const urlParams = new URLSearchParams(window.location.search)
+    const urlFull = urlParams.get('full') || sessionStorage.getItem('een_url_full')
+    if (urlFull === '1' && !document.fullscreenElement) {
+      // Browsers require a real user gesture for fullscreen — show a prompt
+      showFullscreenPrompt.value = true
+    }
   }
 
   // Check for mute URL parameter (overrides localStorage)
@@ -248,6 +249,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleEscKey)
+  document.removeEventListener('keydown', handleFullscreenPromptEscKey)
   document.removeEventListener('fullscreenchange', onFullscreenChange)
   clearQrHoverTimer()
   clearQrLeaveTimer()
@@ -258,7 +260,6 @@ watch(() => authStore.isAuthenticated, loadUser)
 
 // Fullscreen toggle
 const isFullscreen = ref(false)
-const fullscreenButtonRef = ref<HTMLButtonElement | null>(null)
 const showFullscreenPrompt = ref(false)
 
 function enterFullscreenFromPrompt() {
@@ -270,7 +271,24 @@ function enterFullscreenFromPrompt() {
 
 function dismissFullscreenPrompt() {
   showFullscreenPrompt.value = false
+  sessionStorage.removeItem('een_url_full')
 }
+
+// Handle ESC key to close fullscreen prompt
+function handleFullscreenPromptEscKey(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    dismissFullscreenPrompt()
+  }
+}
+
+// Watch fullscreen prompt state to add/remove ESC key listener
+watch(showFullscreenPrompt, (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('keydown', handleFullscreenPromptEscKey)
+  } else {
+    document.removeEventListener('keydown', handleFullscreenPromptEscKey)
+  }
+})
 
 function toggleFullscreen() {
   if (document.fullscreenElement) {
@@ -307,7 +325,6 @@ function onFullscreenChange() {
         <div class="flex items-center gap-2 text-xl font-semibold">
           <!-- Eye icon — fullscreen toggle -->
           <button
-            ref="fullscreenButtonRef"
             @click="toggleFullscreen"
             class="hover:opacity-80 transition-opacity cursor-pointer"
             :title="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"

--- a/src/components/CameraCard.vue
+++ b/src/components/CameraCard.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   selected: boolean
   isPlaying?: boolean
   isDark?: boolean
+  refreshKey?: number
 }>()
 
 const emit = defineEmits<{
@@ -208,6 +209,15 @@ watch(() => props.camera.id, () => {
   stopReconnectTimer()
   resetReconnectAttempts()
   initializePreview()
+})
+
+// Watch for refresh key changes (triggered by refresh button or tab visibility)
+watch(() => props.refreshKey, (newVal, oldVal) => {
+  if (newVal !== undefined && oldVal !== undefined && newVal !== oldVal) {
+    stopReconnectTimer()
+    resetReconnectAttempts()
+    initializePreview()
+  }
 })
 
 onMounted(() => {

--- a/src/components/CameraSidebar.vue
+++ b/src/components/CameraSidebar.vue
@@ -41,6 +41,9 @@ const inaccessibleCameraIds = ref<string[]>([]) // Camera IDs from URL that user
 // Camera selection modal state
 const showCameraSelectModal = ref(false)
 
+// Key to trigger preview stream restart on all visible cards
+const previewRefreshKey = ref(0)
+
 // Pagination state - using dynamic calculation based on viewport
 const currentPage = ref(1)
 const camerasPerPage = ref(4) // Default, will be recalculated
@@ -261,9 +264,17 @@ function handleCameraSelect(camera: Camera) {
   emit('select-camera', camera)
 }
 
-// Refresh cameras
+// Refresh cameras and restart preview streams
 async function refresh() {
   await fetchCameras()
+  previewRefreshKey.value++
+}
+
+// Restart preview streams when tab becomes visible again
+function handleVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    previewRefreshKey.value++
+  }
 }
 
 // Handle camera selection modal confirm
@@ -322,6 +333,9 @@ onMounted(async () => {
 
   // Also listen to window resize as fallback
   window.addEventListener('resize', handleResize)
+
+  // Restart preview streams when tab becomes visible
+  document.addEventListener('visibilitychange', handleVisibilityChange)
 })
 
 onUnmounted(() => {
@@ -329,6 +343,7 @@ onUnmounted(() => {
     resizeObserver.disconnect()
   }
   window.removeEventListener('resize', handleResize)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 </script>
 
@@ -485,6 +500,7 @@ onUnmounted(() => {
             :selected="item.camera.id === selectedCameraId"
             :is-playing="item.camera.id === selectedCameraId && isLivePlayback"
             :is-dark="isDark"
+            :refresh-key="previewRefreshKey"
             @select="handleCameraSelect"
           />
           <ErrorCameraCard

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -159,6 +159,13 @@ router.beforeEach((to, _from, next) => {
     } else {
       sessionStorage.removeItem('een_url_mute')
     }
+
+    // Store fullscreen (full)
+    if (to.query.full !== undefined) {
+      sessionStorage.setItem('een_url_full', to.query.full as string)
+    } else {
+      sessionStorage.removeItem('een_url_full')
+    }
   }
 
   if (to.meta.requiresAuth && !isAuthenticated()) {

--- a/src/utils/clearUrlSessionStorage.ts
+++ b/src/utils/clearUrlSessionStorage.ts
@@ -11,4 +11,5 @@ export function clearUrlSessionStorage() {
   sessionStorage.removeItem('een_url_filter')
   sessionStorage.removeItem('een_url_dark')
   sessionStorage.removeItem('een_url_mute')
+  sessionStorage.removeItem('een_url_full')
 }

--- a/src/views/Callback.vue
+++ b/src/views/Callback.vue
@@ -44,8 +44,9 @@ onMounted(async () => {
   const storedLive = sessionStorage.getItem('een_url_live')
   const storedFilter = sessionStorage.getItem('een_url_filter')
   const storedDark = sessionStorage.getItem('een_url_dark')
+  const storedFull = sessionStorage.getItem('een_url_full')
 
-  if (storedCameraIds || storedSelected || storedEvents || storedEd || storedAd || storedEr || storedAr || storedLive || storedFilter || storedDark) {
+  if (storedCameraIds || storedSelected || storedEvents || storedEd || storedAd || storedEr || storedAr || storedLive || storedFilter || storedDark || storedFull) {
     const query: Record<string, string> = {}
     if (storedCameraIds) query.id = storedCameraIds
     if (storedSelected) query.selected = storedSelected
@@ -57,6 +58,7 @@ onMounted(async () => {
     if (storedLive) query.live = storedLive
     if (storedFilter) query.filter = storedFilter
     if (storedDark) query.dark = storedDark
+    if (storedFull) query.full = storedFull
     router.push({ path: '/', query })
   } else {
     router.push('/')

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, inject, watch } from 'vue'
+import { ref, onMounted, onUnmounted, computed, inject, watch } from 'vue'
 import type { Ref } from 'vue'
 import { getCurrentUser } from 'een-api-toolkit'
 import type { Camera } from 'een-api-toolkit'
@@ -437,6 +437,10 @@ onMounted(async () => {
   document.addEventListener('fullscreenchange', handleFullscreenChange)
   // Sync initial state in case App.vue already entered fullscreen
   isFullscreen.value = !!document.fullscreenElement
+})
+
+onUnmounted(() => {
+  document.removeEventListener('fullscreenchange', handleFullscreenChange)
 })
 
 // Watch for dark mode and mute changes and update URL

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -170,6 +170,9 @@ const initialEventFilter = computed(() => {
   return filter === '1'
 })
 
+// Track fullscreen state for URL sync
+const isFullscreen = ref(!!document.fullscreenElement)
+
 // Selected camera state
 const selectedCamera = ref<Camera | null>(null)
 
@@ -247,6 +250,11 @@ function updateUrl() {
     newQuery.mute = '1'
   }
 
+  // Add fullscreen parameter (only if enabled)
+  if (isFullscreen.value) {
+    newQuery.full = '1'
+  }
+
   // Only update if different to avoid unnecessary history entries
   const currentId = route.query.id as string | undefined
   const currentSelected = route.query.selected as string | undefined
@@ -259,7 +267,8 @@ function updateUrl() {
   const currentFilter = route.query.filter as string | undefined
   const currentDark = route.query.dark as string | undefined
   const currentMute = route.query.mute as string | undefined
-  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events || currentEd !== newQuery.ed || currentAd !== newQuery.ad || currentEr !== newQuery.er || currentAr !== newQuery.ar || currentLive !== newQuery.live || currentFilter !== newQuery.filter || currentDark !== newQuery.dark || currentMute !== newQuery.mute) {
+  const currentFull = route.query.full as string | undefined
+  if (currentId !== newQuery.id || currentSelected !== newQuery.selected || currentEvents !== newQuery.events || currentEd !== newQuery.ed || currentAd !== newQuery.ad || currentEr !== newQuery.er || currentAr !== newQuery.ar || currentLive !== newQuery.live || currentFilter !== newQuery.filter || currentDark !== newQuery.dark || currentMute !== newQuery.mute || currentFull !== newQuery.full) {
     router.replace({ query: newQuery })
   }
 }
@@ -403,6 +412,12 @@ function handleEventFilterChange(enabled: boolean) {
 // Computed events list from EventsPanel (for MainVideoPlayer to check before API calls)
 const eventsList = computed(() => eventsPanelRef.value?.events || [])
 
+// Sync fullscreen state from document to URL
+function handleFullscreenChange() {
+  isFullscreen.value = !!document.fullscreenElement
+  updateUrl()
+}
+
 onMounted(async () => {
   const result = await getCurrentUser()
 
@@ -417,6 +432,11 @@ onMounted(async () => {
   }
 
   loading.value = false
+
+  // Track fullscreen changes for URL sync
+  document.addEventListener('fullscreenchange', handleFullscreenChange)
+  // Sync initial state in case App.vue already entered fullscreen
+  isFullscreen.value = !!document.fullscreenElement
 })
 
 // Watch for dark mode and mute changes and update URL


### PR DESCRIPTION
## Summary
- Add `full=1` URL parameter to request fullscreen mode on page load (with user confirmation prompt since browsers require a real gesture)
- Add preview stream restart when tab becomes visible or refresh button is clicked
- Persist fullscreen state through OAuth login flow and URL sync

## Test plan
- [x] All 51 E2E tests pass (6.9m)
- [x] Build passes (`vue-tsc --noEmit && vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)