### PR TITLE
Dedup shared logic into utils; remove dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Vue 3 single-page application for Eagle Eye Networks camera monitoring. Uses the
 |---------|-------------|
 | `npm run dev` | Start dev server at `http://127.0.0.1:3333` (kills existing port 3333 process first) |
 | `npm run build` | Type-check with `vue-tsc --noEmit` then build with Vite |
-| `npm test` | Run all 51 Playwright E2E tests (requires dev server + OAuth proxy) |
+| `npm test` | Run all 51 Playwright E2E tests across 10 spec files (requires dev server + OAuth proxy) |
 | `npx playwright test tests/events.spec.ts` | Run a single test file |
 | `npx playwright test -g "should toggle dark mode"` | Run a single test by name |
 | `npx playwright test --ui` | Interactive Playwright UI |
@@ -52,7 +52,7 @@ Composables in `src/composables/` manage shared state as module-level singletons
 - `useHlsPlayer()` — HLS.js player setup and teardown
 
 ### URL State
-All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`, `mute`, `full`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction.
+All view state is encoded in URL params (`id`, `selected`, `events`, `ed`, `ad`, `er`, `ar`, `live`, `filter`, `dark`, `mute`, `full`). Event types use 3-char DJB2 base62 hashes (see `src/utils/eventTypeHash.ts`). URL auto-updates on user interaction. Because all state lives in the URL, `App.vue` renders a QR code (via the `qrcode` package) of the current URL so the exact view can be opened on another device.
 
 ### Dark Mode
 Toggles `dark` class on `<html>` element. Tailwind CSS scopes dark styles. Persists via localStorage (`een_dark_mode`) and sessionStorage through OAuth flow. URL param `dark=1` overrides stored preference.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.58",
+      "version": "1.0.59",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -15,6 +15,7 @@ interface AlertWithNotification extends Alert {
 }
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
+import { humanizeEenType } from '@/utils/eenTypeName'
 
 const props = defineProps<{
   camera: Camera | null
@@ -148,17 +149,9 @@ function formatTimestamp(timestamp: string): string {
   return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
-// Get human-readable alert type name
+// Get human-readable alert type name (e.g. "een.motionDetectionAlert.v1" -> "Motion Detection")
 function getAlertTypeName(type: string): string {
-  // Parse the type string (e.g., "een.motionDetectionAlert.v1" -> "Motion Detection")
-  const match = type.match(/een\.(\w+)Alert\.v\d+/)
-  if (match) {
-    return match[1]
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/^./, str => str.toUpperCase())
-      .trim()
-  }
-  return type
+  return humanizeEenType(type)
 }
 
 // Handle alert click - emit alert data for display (exclude notifications as they're accessible via icons)

--- a/src/components/CameraCard.vue
+++ b/src/components/CameraCard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
 import { listFeeds, initMediaSession, getCamera } from 'een-api-toolkit'
-import type { Camera, CameraStatus, Feed } from 'een-api-toolkit'
+import type { Camera, Feed } from 'een-api-toolkit'
+import { getCameraStatusString, isCameraOnline, statusBadgeClass } from '@/utils/cameraStatus'
 
 const props = defineProps<{
   camera: Camera
@@ -74,41 +75,12 @@ function handleImageError() {
   }
 }
 
-// Helper to extract status string from the union type
-function getStatusString(status?: CameraStatus | { connectionStatus?: CameraStatus }): CameraStatus | undefined {
-  if (!status) return undefined
-  if (typeof status === 'string') return status
-  return status.connectionStatus
-}
-
-// Check if camera is in a viewable state
-function isCameraOnline(status?: CameraStatus | { connectionStatus?: CameraStatus }): boolean {
-  const statusStr = getStatusString(status)
-  return statusStr === 'online' || statusStr === 'streaming' || statusStr === 'registered'
-}
-
 // Computed status values
-const statusString = computed(() => getStatusString(props.camera.status))
+const statusString = computed(() => getCameraStatusString(props.camera.status))
 const isOnline = computed(() => isCameraOnline(props.camera.status))
 
 // Status badge styling
-const statusClass = computed(() => {
-  const statusStr = statusString.value
-  switch (statusStr) {
-    case 'online':
-    case 'streaming':
-      return 'bg-green-500'
-    case 'offline':
-    case 'deviceOffline':
-    case 'bridgeOffline':
-      return 'bg-gray-500'
-    case 'error':
-    case 'invalidCredentials':
-      return 'bg-red-500'
-    default:
-      return 'bg-yellow-500'
-  }
-})
+const statusClass = computed(() => statusBadgeClass(props.camera.status))
 
 // Stop the retry timer for offline cameras
 function stopRetryTimer() {

--- a/src/components/EventTypesPanel.vue
+++ b/src/components/EventTypesPanel.vue
@@ -3,6 +3,7 @@ import { ref, watch, computed, onMounted } from 'vue'
 import { listEventFieldValues, listEventTypes } from 'een-api-toolkit'
 import type { Camera, EenError } from 'een-api-toolkit'
 import { buildHashLookup, hashStringToEventTypes } from '@/utils/eventTypeHash'
+import { humanizeEenType } from '@/utils/eenTypeName'
 
 const props = defineProps<{
   camera: Camera | null
@@ -52,18 +53,7 @@ async function fetchEventTypeNames() {
 
 // Get human-readable event type name
 function getEventTypeName(type: string): string {
-  const name = eventTypeNames.value.get(type)
-  if (name) return name
-
-  // Fallback: parse the type string
-  const match = type.match(/een\.(\w+)Event\.v\d+/)
-  if (match) {
-    return match[1]
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/^./, str => str.toUpperCase())
-      .trim()
-  }
-  return type
+  return eventTypeNames.value.get(type) ?? humanizeEenType(type)
 }
 
 // Short name for display in tight spaces

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -13,6 +13,7 @@ import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
 import { useSseNotification } from '@/composables/useSseNotification'
 import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
+import { humanizeEenType } from '@/utils/eenTypeName'
 import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
@@ -163,18 +164,7 @@ async function fetchEventTypeNames() {
 
 // Get human-readable event type name
 function getEventTypeName(type: string): string {
-  const name = eventTypeNames.value.get(type)
-  if (name) return name
-
-  // Fallback: parse the type string
-  const match = type.match(/een\.(\w+)Event\.v\d+/)
-  if (match) {
-    return match[1]
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/^./, str => str.toUpperCase())
-      .trim()
-  }
-  return type
+  return eventTypeNames.value.get(type) ?? humanizeEenType(type)
 }
 
 // Get formatted duration from event start/end timestamps
@@ -472,7 +462,7 @@ async function reconnect() {
     subscriptionId.value = null
   }
 
-  await connectWithoutClearingEvents()
+  await connect()
   isProactiveReconnecting = false
 }
 
@@ -514,19 +504,6 @@ function handleSseError(error: Error) {
 
 // Connect to SSE stream
 async function connect() {
-  if (!props.camera || props.selectedTypes.length === 0) return
-
-  connectionAttemptId++
-  const currentAttemptId = connectionAttemptId
-
-  connectionStatus.value = 'connecting'
-  connectionError.value = null
-
-  await createAndConnectSubscription(currentAttemptId)
-}
-
-// Connect without clearing events (for proactive reconnection)
-async function connectWithoutClearingEvents() {
   if (!props.camera || props.selectedTypes.length === 0) return
 
   connectionAttemptId++

--- a/src/components/MainVideoPlayer.vue
+++ b/src/components/MainVideoPlayer.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue'
 import { useAuthStore, getEvent, getCamera, getCameraSettings, getBridge, getDataSchemasForEventType, movePtz, getPtzSettings, getPtzPosition } from 'een-api-toolkit'
-import type { Camera, CameraStatus, PtzDirection, PtzPreset, PtzPositionResponse } from 'een-api-toolkit'
+import type { Camera, PtzDirection, PtzPreset, PtzPositionResponse } from 'een-api-toolkit'
+import { getCameraStatusString, isCameraOnline, statusBadgeClass } from '@/utils/cameraStatus'
 import LivePlayer from '@een/live-video-web-sdk'
 import { useHlsPlayer } from '@/composables/useHlsPlayer'
 import { useVideoExport } from '@/composables/useVideoExport'
@@ -452,21 +453,8 @@ async function handleDownloadClick(e: Event) {
   }
 }
 
-// Helper to extract status string from the union type
-function getStatusString(status?: CameraStatus | { connectionStatus?: CameraStatus }): CameraStatus | undefined {
-  if (!status) return undefined
-  if (typeof status === 'string') return status
-  return status.connectionStatus
-}
-
-// Check if camera is in a viewable state
-function isCameraOnline(status?: CameraStatus | { connectionStatus?: CameraStatus }): boolean {
-  const statusStr = getStatusString(status)
-  return statusStr === 'online' || statusStr === 'streaming' || statusStr === 'registered'
-}
-
 // Computed status values
-const statusString = computed(() => getStatusString(props.camera.status))
+const statusString = computed(() => getCameraStatusString(props.camera.status))
 
 // Google Maps URL from camera devicePosition
 const googleMapsUrl = computed(() => {
@@ -490,23 +478,7 @@ const googleMapsTooltip = computed(() => {
 const isOnline = computed(() => isCameraOnline(props.camera.status))
 
 // Status badge styling
-const statusClass = computed(() => {
-  const statusStr = statusString.value
-  switch (statusStr) {
-    case 'online':
-    case 'streaming':
-      return 'bg-green-500'
-    case 'offline':
-    case 'deviceOffline':
-    case 'bridgeOffline':
-      return 'bg-gray-500'
-    case 'error':
-    case 'invalidCredentials':
-      return 'bg-red-500'
-    default:
-      return 'bg-yellow-500'
-  }
-})
+const statusClass = computed(() => statusBadgeClass(props.camera.status))
 
 // Format playback timestamp for display in local timezone
 const formattedPlaybackTimestamp = computed(() => {

--- a/src/utils/cameraStatus.ts
+++ b/src/utils/cameraStatus.ts
@@ -1,0 +1,31 @@
+import { getCameraStatusString } from 'een-api-toolkit'
+import type { CameraStatus } from 'een-api-toolkit'
+
+type CameraStatusInput = CameraStatus | { connectionStatus?: CameraStatus } | undefined
+
+// Re-export the toolkit helper so callers have a single import for status concerns
+export { getCameraStatusString }
+
+// Check if a camera is in a viewable (live-streamable) state
+export function isCameraOnline(status?: CameraStatusInput): boolean {
+  const statusStr = getCameraStatusString(status)
+  return statusStr === 'online' || statusStr === 'streaming' || statusStr === 'registered'
+}
+
+// Tailwind background class for the status dot/badge
+export function statusBadgeClass(status?: CameraStatusInput): string {
+  switch (getCameraStatusString(status)) {
+    case 'online':
+    case 'streaming':
+      return 'bg-green-500'
+    case 'offline':
+    case 'deviceOffline':
+    case 'bridgeOffline':
+      return 'bg-gray-500'
+    case 'error':
+    case 'invalidCredentials':
+      return 'bg-red-500'
+    default:
+      return 'bg-yellow-500'
+  }
+}

--- a/src/utils/eenTypeName.ts
+++ b/src/utils/eenTypeName.ts
@@ -1,0 +1,13 @@
+// Derive a human-readable label from an EEN event/alert type string.
+// e.g. "een.motionDetectionEvent.v1" / "een.motionDetectionAlert.v1" -> "Motion Detection"
+// Falls back to the raw type string when it doesn't match the expected pattern.
+export function humanizeEenType(type: string): string {
+  const match = type.match(/een\.(\w+)(?:Event|Alert)\.v\d+/)
+  if (match) {
+    return match[1]
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^./, str => str.toUpperCase())
+      .trim()
+  }
+  return type
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -363,7 +363,6 @@ const selectedEventTypes = ref<string[]>([])
 
 // References for cross-panel communication
 const eventsPanelRef = ref<InstanceType<typeof EventsPanel> | null>(null)
-const alertsPanelRef = ref<InstanceType<typeof AlertsPanel> | null>(null)
 
 // Handle event type selection changes
 function handleEventTypesUpdate(types: string[]) {
@@ -552,7 +551,6 @@ watch(isMuted, () => {
             <!-- Alerts Panel -->
             <div class="flex-1 min-w-0 p-3">
               <AlertsPanel
-                ref="alertsPanelRef"
                 :camera="selectedCamera"
                 :selected-types="selectedEventTypes"
                 :is-dark="isDark"


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup from a repo-wide `/simplify` review. Extracts duplicated logic into shared utilities and removes dead code. Net **−54 lines**.

- **`src/utils/cameraStatus.ts`** — `isCameraOnline` / `statusBadgeClass` built on the toolkit's existing `getCameraStatusString`. Replaces byte-identical local copies in `CameraCard.vue` and `MainVideoPlayer.vue` (and stops re-rolling a function the toolkit already ships).
- **`src/utils/eenTypeName.ts`** — `humanizeEenType` (the `een.xxxEvent/Alert.vN → "Title Case"` parser). Replaces three copies in `EventsPanel`, `EventTypesPanel`, `AlertsPanel`.
- Remove `connectWithoutClearingEvents` in `EventsPanel` — byte-identical to `connect()`; `reconnect()` now calls `connect()`.
- Remove dead `alertsPanelRef` in `Home.vue` (declared + bound, never read).
- `CLAUDE.md` — correct test count to 51 across 10 spec files; note the QR companion feature.

## Testing

- `npm run build` (vue-tsc + vite) ✅
- Full Playwright E2E suite: **51 passed** ✅

## Follow-ups (deferred, tracked as issues)

Larger architectural refactors from the same review were intentionally left out and filed as separate issues: unified URL-param table, Events/Alerts panel composables, hot-path memoization, fetch parallelization. A correctness bug (`mute` missing from the OAuth-restore path) was also filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)