### PR TITLE
Docs: note Vitest in README Technology Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Since browsers require a real user gesture for the Fullscreen API, a confirmatio
 - **API Integration:** [een-api-toolkit](https://www.npmjs.com/package/een-api-toolkit)
 - **Live Video:** @een/live-video-web-sdk
 - **Recorded Video:** hls.js
-- **Testing:** Playwright (E2E)
+- **Testing:** Vitest (unit) + Playwright (E2E)
 
 ## een-api-toolkit Functions Used
 


### PR DESCRIPTION
Second independent PR (does not depend on #77).

## Change
- README Technology Stack: update the Testing entry from "Playwright (E2E)" to "Vitest (unit) + Playwright (E2E)" to reflect the unit-test suite.

Docs-only; no code or behavior change. Targets `develop`, so it runs the `review` + `unit` checks.