### PR TITLE
Simplify: dedup type-humanizer/timestamp helpers, tidy exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -16,6 +16,7 @@ interface AlertWithNotification extends Alert {
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
 import { humanizeEenType } from '@/utils/eenTypeName'
+import { formatTimestamp } from '@/utils/formatTime'
 
 const props = defineProps<{
   camera: Camera | null
@@ -143,11 +144,6 @@ function getStartTimestamp(): string {
   return new Date(now - selectedTimeRange.value * 60 * 1000).toISOString()
 }
 
-// Format timestamp for display
-function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
 
 // Get human-readable alert type name (e.g. "een.motionDetectionAlert.v1" -> "Motion Detection")
 function getAlertTypeName(type: string): string {

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -14,6 +14,7 @@ import { useEventAge } from '@/composables/useEventAge'
 import { useSseNotification } from '@/composables/useSseNotification'
 import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
 import { humanizeEenType } from '@/utils/eenTypeName'
+import { formatTimestamp } from '@/utils/formatTime'
 import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
@@ -264,11 +265,6 @@ function getEevaReason(event: Event): string | null {
   return reason || null
 }
 
-// Format timestamp for display
-function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
 
 // Check if active event is still in the list
 function isActiveEventInList(): boolean {

--- a/src/composables/useVideoExport.ts
+++ b/src/composables/useVideoExport.ts
@@ -314,8 +314,6 @@ export function useVideoExport() {
   return {
     // State
     status,
-    jobId,
-    job,
     progress,
     progressPercent,
     errorMessage,

--- a/src/utils/eenTypeName.ts
+++ b/src/utils/eenTypeName.ts
@@ -1,8 +1,10 @@
 // Derive a human-readable label from an EEN event/alert type string.
 // e.g. "een.motionDetectionEvent.v1" / "een.motionDetectionAlert.v1" -> "Motion Detection"
 // Falls back to the raw type string when it doesn't match the expected pattern.
+const EEN_TYPE_PATTERN = /een\.(\w+)(?:Event|Alert)\.v\d+/
+
 export function humanizeEenType(type: string): string {
-  const match = type.match(/een\.(\w+)(?:Event|Alert)\.v\d+/)
+  const match = type.match(EEN_TYPE_PATTERN)
   if (match) {
     return match[1]
       .replace(/([A-Z])/g, ' $1')

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,5 @@
+// Format an ISO timestamp as a local clock time (HH:MM:SS) for list display.
+export function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,6 +11,7 @@ import EventsPanel from '../components/EventsPanel.vue'
 import AlertsPanel from '../components/AlertsPanel.vue'
 import type { BoundingBox } from '@/composables/useBoundingBoxes'
 import { eventTypesToHashString } from '@/utils/eventTypeHash'
+import { humanizeEenType } from '@/utils/eenTypeName'
 
 // Inject dark mode and mute state
 const isDark = inject<Ref<boolean>>('isDark', ref(false))
@@ -97,12 +98,10 @@ const DURATION_URL_TO_MINUTES: Record<string, number> = {
   '1w': 10080
 }
 
-const DURATION_MINUTES_TO_URL: Record<number, string> = {
-  10: '10m',
-  60: '1h',
-  1440: '24h',
-  10080: '1w'
-}
+// Inverse of DURATION_URL_TO_MINUTES, derived so the two never drift
+const DURATION_MINUTES_TO_URL: Record<number, string> = Object.fromEntries(
+  Object.entries(DURATION_URL_TO_MINUTES).map(([url, minutes]) => [minutes, url])
+)
 
 // Parse duration URL value to minutes (returns null if invalid)
 function parseDurationUrl(value: string | null): number | null {
@@ -332,7 +331,7 @@ function handleAlertClick(alert: { alertId: string; alertObject: Record<string, 
 
   // Extract alert type name
   const alertType = alert.alertObject.alertType as string | undefined
-  const alertTypeName = alertType ? getAlertTypeName(alertType) : 'Alert'
+  const alertTypeName = alertType ? humanizeEenType(alertType) : 'Alert'
 
   // Extract alert timestamp
   const alertTimestamp = alert.alertObject.timestamp as string | null
@@ -344,18 +343,6 @@ function handleAlertClick(alert: { alertId: string; alertObject: Record<string, 
   playbackEventId.value = null // Clear event ID since this is an alert
   playbackBoundingBoxes.value = [] // Alerts don't have bounding boxes
   playbackEventObject.value = alert.alertObject
-}
-
-// Get human-readable alert type name
-function getAlertTypeName(type: string): string {
-  const match = type.match(/een\.(\w+)Alert\.v\d+/)
-  if (match) {
-    return match[1]
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/^./, str => str.toUpperCase())
-      .trim()
-  }
-  return type
 }
 
 // Selected event types state (shared between panels)


### PR DESCRIPTION
Behavior-preserving cleanups from a repo-wide `/simplify` review. No runtime behavior change.

## Changes
- **Home.vue:** removed a 4th copy of the EEN type-name humanizer (`getAlertTypeName`) — now uses the shared `humanizeEenType`.
- **Home.vue:** `DURATION_MINUTES_TO_URL` is now derived from `DURATION_URL_TO_MINUTES` via `Object.fromEntries`, so the inverse map can't drift.
- **useVideoExport:** stopped exporting `jobId`/`job` (consumed by no component; kept module-private for internal polling).
- **eenTypeName.ts:** hoisted the match regex to a module constant (it's called per event/alert row).
- **formatTimestamp:** extracted the byte-identical copy from `EventsPanel` + `AlertsPanel` into `src/utils/formatTime.ts`.

## Verification
- `npm run build` (vue-tsc + vite) ✅
- `npm run test:unit` — 12/12 ✅
- Behavioral coverage via the existing Playwright E2E suite (runs on the `develop -> production` PR).

## Scope notes
Larger structural findings from the same review were intentionally **not** bundled here — they're either already tracked (#69–#73) or warrant their own issues (duration-vocab util, Events↔MainVideoPlayer extraction, `usePersistedBoolean`, isDark prop-vs-inject, double `listEventTypes` fetch).