### PR TITLE
Release: CI action bumps + shared-util simplifications + README docs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -37,10 +37,10 @@ jobs:
           VITE_PROXY_URL: ${{ secrets.VITE_PROXY_URL }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -53,14 +53,14 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   release:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -43,7 +43,7 @@ jobs:
           retention-days: 7
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-results

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Allow the Claude GitHub App's bot to trigger reviews (e.g. when it
+          # pushes commits to a PR branch). Without this, the action's default
+          # human-actor gate fails bot-initiated runs. Matching strips the
+          # trailing [bot] suffix, so "claude[bot]" and "claude" are equivalent.
+          allowed_bots: "claude[bot]"
           prompt: |
             Please review this pull request and provide constructive feedback on:
             1. Code quality and best practices

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
             ${{ steps.read-prompts.outputs.extra_prompt }}
 
       - name: Extract and Post Review Comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           EXEC_FILE: ${{ steps.claude-review.outputs.execution_file }}
         with:

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Since browsers require a real user gesture for the Fullscreen API, a confirmatio
 - **API Integration:** [een-api-toolkit](https://www.npmjs.com/package/een-api-toolkit)
 - **Live Video:** @een/live-video-web-sdk
 - **Recorded Video:** hls.js
-- **Testing:** Playwright (E2E)
+- **Testing:** Vitest (unit) + Playwright (E2E)
 
 ## een-api-toolkit Functions Used
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ This application uses the following functions from [een-api-toolkit](https://git
 | `npm run dev` | Start development server |
 | `npm run build` | Build for production |
 | `npm run preview` | Preview production build |
+| `npm run test:unit` | Run Vitest unit tests |
 | `npm test` | Run Playwright E2E tests |
 | `npm run test:e2e` | Run Playwright E2E tests (alias) |
 | `npm run test:ui` | Run Playwright tests with interactive UI |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.66",
+      "version": "1.0.67",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.65",
+      "version": "1.0.66",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -16,6 +16,7 @@ interface AlertWithNotification extends Alert {
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
 import { humanizeEenType } from '@/utils/eenTypeName'
+import { formatTimestamp } from '@/utils/formatTime'
 
 const props = defineProps<{
   camera: Camera | null
@@ -143,11 +144,6 @@ function getStartTimestamp(): string {
   return new Date(now - selectedTimeRange.value * 60 * 1000).toISOString()
 }
 
-// Format timestamp for display
-function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
 
 // Get human-readable alert type name (e.g. "een.motionDetectionAlert.v1" -> "Motion Detection")
 function getAlertTypeName(type: string): string {

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -16,7 +16,7 @@ interface AlertWithNotification extends Alert {
 import { useImageCache } from '@/composables/useImageCache'
 import { useEventAge } from '@/composables/useEventAge'
 import { humanizeEenType } from '@/utils/eenTypeName'
-import { formatTimestamp } from '@/utils/formatTime'
+import { formatClockTime } from '@/utils/formatTime'
 
 const props = defineProps<{
   camera: Camera | null
@@ -875,7 +875,7 @@ onUnmounted(() => {
             </template>
           </div>
           <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-500' : 'text-gray-400'">
-            <span>{{ formatTimestamp(alert.timestamp) }}</span>
+            <span>{{ formatClockTime(alert.timestamp) }}</span>
             <span :class="isDark ? 'text-gray-300' : 'text-gray-700'">{{ formatAge(alert.timestamp) }}</span>
           </div>
         </div>

--- a/src/components/AlertsPanel.vue
+++ b/src/components/AlertsPanel.vue
@@ -144,7 +144,6 @@ function getStartTimestamp(): string {
   return new Date(now - selectedTimeRange.value * 60 * 1000).toISOString()
 }
 
-
 // Get human-readable alert type name (e.g. "een.motionDetectionAlert.v1" -> "Motion Detection")
 function getAlertTypeName(type: string): string {
   return humanizeEenType(type)

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -14,6 +14,7 @@ import { useEventAge } from '@/composables/useEventAge'
 import { useSseNotification } from '@/composables/useSseNotification'
 import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
 import { humanizeEenType } from '@/utils/eenTypeName'
+import { formatTimestamp } from '@/utils/formatTime'
 import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
@@ -264,11 +265,6 @@ function getEevaReason(event: Event): string | null {
   return reason || null
 }
 
-// Format timestamp for display
-function formatTimestamp(timestamp: string): string {
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
 
 // Check if active event is still in the list
 function isActiveEventInList(): boolean {

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -14,7 +14,7 @@ import { useEventAge } from '@/composables/useEventAge'
 import { useSseNotification } from '@/composables/useSseNotification'
 import { extractBoundingBoxes, type BoundingBox } from '@/composables/useBoundingBoxes'
 import { humanizeEenType } from '@/utils/eenTypeName'
-import { formatTimestamp } from '@/utils/formatTime'
+import { formatClockTime } from '@/utils/formatTime'
 import BoundingBoxOverlay from './BoundingBoxOverlay.vue'
 
 const props = defineProps<{
@@ -1052,7 +1052,7 @@ watch(
             {{ getEventTypeName(event.type) }}<span v-if="getEventDuration(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> ({{ getEventDuration(event) }})</span><span v-if="getEventConfidence(event)" :class="isDark ? 'text-gray-400' : 'text-gray-400'"> - {{ getEventConfidence(event) }} confidence<span v-if="getEventConfidenceCount(event)"> ({{ getEventConfidenceCount(event) }})</span></span><span v-if="getEevaReason(event)" :class="isDark ? 'text-gray-400' : 'text-gray-500'"> - {{ getEevaReason(event) }}</span>
           </div>
           <div class="text-xs flex justify-between" :class="isDark ? 'text-gray-400' : 'text-gray-400'">
-            <span>{{ formatTimestamp(event.startTimestamp) }}</span>
+            <span>{{ formatClockTime(event.startTimestamp) }}</span>
             <span :class="isDark ? 'text-gray-300' : 'text-gray-700'">{{ formatAge(event.startTimestamp) }}</span>
           </div>
         </div>

--- a/src/components/EventsPanel.vue
+++ b/src/components/EventsPanel.vue
@@ -265,7 +265,6 @@ function getEevaReason(event: Event): string | null {
   return reason || null
 }
 
-
 // Check if active event is still in the list
 function isActiveEventInList(): boolean {
   if (!props.activeEventId) return false

--- a/src/composables/useVideoExport.ts
+++ b/src/composables/useVideoExport.ts
@@ -314,8 +314,6 @@ export function useVideoExport() {
   return {
     // State
     status,
-    jobId,
-    job,
     progress,
     progressPercent,
     errorMessage,

--- a/src/utils/eenTypeName.test.ts
+++ b/src/utils/eenTypeName.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { humanizeEenType } from './eenTypeName'
+
+describe('humanizeEenType', () => {
+  it('humanizes a multi-word Event type', () => {
+    expect(humanizeEenType('een.motionDetectionEvent.v1')).toBe('Motion Detection')
+  })
+
+  it('humanizes the equivalent Alert type identically', () => {
+    expect(humanizeEenType('een.motionDetectionAlert.v1')).toBe('Motion Detection')
+  })
+
+  it('handles a single-word type', () => {
+    expect(humanizeEenType('een.motionAlert.v1')).toBe('Motion')
+  })
+
+  it('ignores the version suffix', () => {
+    expect(humanizeEenType('een.personDetectionEvent.v2')).toBe('Person Detection')
+    expect(humanizeEenType('een.personDetectionEvent.v10')).toBe('Person Detection')
+  })
+
+  it('falls back to the raw string when it does not match the pattern', () => {
+    expect(humanizeEenType('not-an-een-type')).toBe('not-an-een-type')
+    expect(humanizeEenType('')).toBe('')
+  })
+})

--- a/src/utils/eenTypeName.ts
+++ b/src/utils/eenTypeName.ts
@@ -1,8 +1,10 @@
 // Derive a human-readable label from an EEN event/alert type string.
 // e.g. "een.motionDetectionEvent.v1" / "een.motionDetectionAlert.v1" -> "Motion Detection"
 // Falls back to the raw type string when it doesn't match the expected pattern.
+const EEN_TYPE_PATTERN = /een\.(\w+)(?:Event|Alert)\.v\d+/
+
 export function humanizeEenType(type: string): string {
-  const match = type.match(/een\.(\w+)(?:Event|Alert)\.v\d+/)
+  const match = type.match(EEN_TYPE_PATTERN)
   if (match) {
     return match[1]
       .replace(/([A-Z])/g, ' $1')

--- a/src/utils/formatTime.test.ts
+++ b/src/utils/formatTime.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { formatTimestamp } from './formatTime'
+
+describe('formatTimestamp', () => {
+  // Output is locale/timezone-dependent, so assert the HH:MM:SS shape
+  // rather than an exact string (works for both 12h and 24h locales).
+  it('formats an ISO timestamp as a clock time with hours, minutes and seconds', () => {
+    expect(formatTimestamp('2026-06-08T22:30:45Z')).toMatch(/\d{1,2}:\d{2}:\d{2}/)
+  })
+
+  it('returns a non-empty string for a valid timestamp', () => {
+    expect(formatTimestamp('2026-01-01T00:00:00Z').length).toBeGreaterThan(0)
+  })
+})

--- a/src/utils/formatTime.test.ts
+++ b/src/utils/formatTime.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { formatTimestamp } from './formatTime'
+import { formatClockTime } from './formatTime'
 
-describe('formatTimestamp', () => {
+describe('formatClockTime', () => {
   // Output is locale/timezone-dependent, so assert the HH:MM:SS shape
   // rather than an exact string (works for both 12h and 24h locales).
   it('formats an ISO timestamp as a clock time with hours, minutes and seconds', () => {
-    expect(formatTimestamp('2026-06-08T22:30:45Z')).toMatch(/\d{1,2}:\d{2}:\d{2}/)
+    expect(formatClockTime('2026-06-08T22:30:45Z')).toMatch(/\d{1,2}:\d{2}:\d{2}/)
   })
 
   it('returns a non-empty string for a valid timestamp', () => {
-    expect(formatTimestamp('2026-01-01T00:00:00Z').length).toBeGreaterThan(0)
+    expect(formatClockTime('2026-01-01T00:00:00Z').length).toBeGreaterThan(0)
   })
 })

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,5 +1,7 @@
 // Format an ISO timestamp as a local clock time (HH:MM:SS) for list display.
-export function formatTimestamp(timestamp: string): string {
+// Named distinctly from een-api-toolkit's `formatTimestamp` (which produces an
+// EEN API timestamp) to avoid an import collision with different semantics.
+export function formatClockTime(timestamp: string): string {
   const date = new Date(timestamp)
   return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,5 @@
+// Format an ISO timestamp as a local clock time (HH:MM:SS) for list display.
+export function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,6 +11,7 @@ import EventsPanel from '../components/EventsPanel.vue'
 import AlertsPanel from '../components/AlertsPanel.vue'
 import type { BoundingBox } from '@/composables/useBoundingBoxes'
 import { eventTypesToHashString } from '@/utils/eventTypeHash'
+import { humanizeEenType } from '@/utils/eenTypeName'
 
 // Inject dark mode and mute state
 const isDark = inject<Ref<boolean>>('isDark', ref(false))
@@ -97,12 +98,10 @@ const DURATION_URL_TO_MINUTES: Record<string, number> = {
   '1w': 10080
 }
 
-const DURATION_MINUTES_TO_URL: Record<number, string> = {
-  10: '10m',
-  60: '1h',
-  1440: '24h',
-  10080: '1w'
-}
+// Inverse of DURATION_URL_TO_MINUTES, derived so the two never drift
+const DURATION_MINUTES_TO_URL: Record<number, string> = Object.fromEntries(
+  Object.entries(DURATION_URL_TO_MINUTES).map(([url, minutes]) => [minutes, url])
+)
 
 // Parse duration URL value to minutes (returns null if invalid)
 function parseDurationUrl(value: string | null): number | null {
@@ -332,7 +331,7 @@ function handleAlertClick(alert: { alertId: string; alertObject: Record<string, 
 
   // Extract alert type name
   const alertType = alert.alertObject.alertType as string | undefined
-  const alertTypeName = alertType ? getAlertTypeName(alertType) : 'Alert'
+  const alertTypeName = alertType ? humanizeEenType(alertType) : 'Alert'
 
   // Extract alert timestamp
   const alertTimestamp = alert.alertObject.timestamp as string | null
@@ -344,18 +343,6 @@ function handleAlertClick(alert: { alertId: string; alertObject: Record<string, 
   playbackEventId.value = null // Clear event ID since this is an alert
   playbackBoundingBoxes.value = [] // Alerts don't have bounding boxes
   playbackEventObject.value = alert.alertObject
-}
-
-// Get human-readable alert type name
-function getAlertTypeName(type: string): string {
-  const match = type.match(/een\.(\w+)Alert\.v\d+/)
-  if (match) {
-    return match[1]
-      .replace(/([A-Z])/g, ' $1')
-      .replace(/^./, str => str.toUpperCase())
-      .trim()
-  }
-  return type
 }
 
 // Selected event types state (shared between panels)


### PR DESCRIPTION
Promotes `develop` to `production`.

## Contents
- **CI: Node 20 action deprecation fixed (#79).** Bumped all official actions to current Node 24 majors across the 6 workflows (`checkout@v6`, `github-script@v9`, `setup-node@v6`, `upload-artifact@v7`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`). This is the first production cycle exercising the bumped `deploy`/`e2e` actions — watch the post-merge Pages deploy.
- **Simplifications (#80, behavior-preserving):** removed a duplicate EEN type-humanizer in `Home.vue` (uses shared `humanizeEenType`), derived `DURATION_MINUTES_TO_URL`, stopped exporting unused `useVideoExport` refs, hoisted a regex constant, and extracted the shared `formatTimestamp` into `src/utils/formatTime.ts`.
- **Docs:** README now lists `npm run test:unit` and notes Vitest in the Technology Stack.

## Verification (on develop)
- `npm run build` (vue-tsc + vite) ✅
- `npm run test:unit` — 12/12 ✅
- Full pipeline (Claude review + unit + E2E + CodeQL) runs on this PR.

No runtime behavior change.