### PR TITLE
CI: allow Claude bot to trigger PR review (fix allowed_bots gate)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Allow the Claude GitHub App's bot to trigger reviews (e.g. when it
+          # pushes commits to a PR branch). Without this, the action's default
+          # human-actor gate fails bot-initiated runs. Matching strips the
+          # trailing [bot] suffix, so "claude[bot]" and "claude" are equivalent.
+          allowed_bots: "claude[bot]"
           prompt: |
             Please review this pull request and provide constructive feedback on:
             1. Code quality and best practices


### PR DESCRIPTION
## Problem
`anthropics/claude-code-action@v1` (a moving major tag) auto-updated to a build that added an **`allowed_bots`** safety gate: it now fails any run whose triggering actor is a bot, unless that bot is allow-listed. When the Claude GitHub App pushed a commit to a PR branch, the resulting `synchronize` run was rejected with:

> Action failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

Human-opened/updated PRs were unaffected (they still reviewed and approved); only bot-initiated runs failed.

## Fix
Add `allowed_bots: "claude[bot]"` to the action inputs in `pr-review.yml`.

Verified against the action's matching logic (`src/github/validation/actor.ts`): it lowercases and strips a trailing `[bot]` from both the actor and each list entry, so `claude[bot]` (the actor) matches the `"claude[bot]"` entry. Chose the specific trusted bot rather than `*` to keep the gate's protection against arbitrary bots.

Loop-safety: this workflow only **posts a review comment**; it never pushes commits, so allowing the bot can't create a review→commit→review loop on its own.

## Validation
- YAML validated.
- The real test is the next bot-triggered `synchronize` on a PR — it should now run the review instead of failing at the gate.