### PR TITLE
chore: bump een-api-toolkit 0.3.103 → 0.3.110

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.3",
-        "een-api-toolkit": "^0.3.103",
+        "een-api-toolkit": "^0.3.110",
         "hls.js": "^1.6.15",
         "pinia": "^3.0.4",
         "qrcode": "^1.5.4",
@@ -1903,15 +1903,15 @@
       }
     },
     "node_modules/een-api-toolkit": {
-      "version": "0.3.103",
-      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.103.tgz",
-      "integrity": "sha512-sixphaju9hsWpRx56oosz1nJk0KIkpSG8AgkKVLyAaOj0k+K4ifJHu6DfkI+w4GIO5Xn1Ck9VlVJKfNwEr96Ag==",
+      "version": "0.3.110",
+      "resolved": "https://registry.npmjs.org/een-api-toolkit/-/een-api-toolkit-0.3.110.tgz",
+      "integrity": "sha512-2VpDAsgSj4nOgJq/lFWQYk8FEryBAX73DPnR7MTPz9QL1luz2CyKBseo8yzWdrB+REoX/uU4myl9ak82SdFJig==",
       "license": "MIT",
       "bin": {
         "een-setup-agents": "scripts/setup-agents.ts"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "pinia": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@een/live-video-web-sdk": "^1.10.2",
     "@vitejs/plugin-vue": "^6.0.3",
-    "een-api-toolkit": "^0.3.103",
+    "een-api-toolkit": "^0.3.110",
     "hls.js": "^1.6.15",
     "pinia": "^3.0.4",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
Updates the core `een-api-toolkit` dependency to the latest published patch.

## Change
- `een-api-toolkit`: `0.3.103` → `0.3.110` (patch bump within `0.3.x`; only `package.json` + `package-lock.json`).

## Verification (locally, on this branch)
- `npm run build` (vue-tsc + vite) ✅ — clean type-check, no API breakage in our usage.
- `npm run test:unit` — 19/19 ✅
- Full Playwright E2E suite — **51 passed**, real OAuth through the **production proxy** (`een-oauth-proxy.klaushofrichter.workers.dev`).

No application code changed.