### PR TITLE
refactor(router): return-value navigation guard (drop deprecated next())

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.67",
+  "version": "1.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-camera-observation-app",
-      "version": "1.0.67",
+      "version": "1.0.68",
       "dependencies": {
         "@een/live-video-web-sdk": "^1.10.2",
         "@vitejs/plugin-vue": "^6.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-camera-observation-app",
-  "version": "1.0.67",
+  "version": "1.0.68",
   "type": "module",
   "scripts": {
     "dev": "lsof -ti:3333 2>/dev/null | xargs kill -9 2>/dev/null; vite",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -65,13 +65,14 @@ function isAuthenticated(): boolean {
   return false
 }
 
-// Navigation guard for protected routes
-router.beforeEach((to, _from, next) => {
+// Navigation guard for protected routes.
+// Uses vue-router's return-value style (return a location to redirect, or
+// undefined to allow) — the next() callback is deprecated as of vue-router 5.
+router.beforeEach((to) => {
   // IMPORTANT: Check for OAuth callback FIRST, before auth check
   // EEN IDP redirects to root path with code and state params
   if (to.path === '/' && to.query.code && to.query.state) {
-    next({ name: 'callback', query: to.query })
-    return
+    return { name: 'callback', query: to.query }
   }
 
   // Handle URL parameters: persist them to sessionStorage so they survive the
@@ -81,10 +82,10 @@ router.beforeEach((to, _from, next) => {
   }
 
   if (to.meta.requiresAuth && !isAuthenticated()) {
-    next({ name: 'login' })
-  } else {
-    next()
+    return { name: 'login' }
   }
+
+  // Otherwise allow navigation (implicit return undefined)
 })
 
 export default router


### PR DESCRIPTION
Follow-up to the vue-router 5 upgrade (#93).

## Why
vue-router 5 **deprecates the `next()` callback** in navigation guards (emits a deprecation warning; removal expected in v6). This migrates `src/router/index.ts`'s `beforeEach` to the return-value style.

## Change
- `next({ name: 'callback', query })` → `return { name: 'callback', query }`
- `next({ name: 'login' })` → `return { name: 'login' }`
- `next()` → implicit `return undefined`
- Guard signature `(to, _from, next)` → `(to)`

**Behavior-preserving**, including the critical ordering: OAuth-callback check still runs **before** the auth check.

## Verification
- `npm run build` (vue-tsc 3 + vite 8) ✅
- `npm run test:unit` — 19/19 ✅
- Full Playwright E2E — **51 passed** (auth, url-state, OAuth-callback redirect specs — the exact behavior this guard drives)